### PR TITLE
Multiple Framework support and extended CoreStart interface, couples of improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TWCore 2.1
-A multipurpose framework library for dotnet core 2.1, dotnet standard 2.0, net461, net462, used to create microservices solutions on multiple platforms (runs on windows, linux, linux-arm [raspberry pi], and osx).
+A multipurpose framework library for dotnet core 2.1, dotnet standard 2.0, net461 and net462 used to create microservices solutions on multiple platforms (runs on windows, linux, linux-arm [raspberry pi], and osx).
 
 # Advantages
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TWCore 2.1
-A multipurpose framework library for dotnet core 2.1, used to create microservices solutions on multiple platforms (runs on windows, linux, linux-arm [raspberry pi], and osx).
+A multipurpose framework library for dotnet core 2.1, dotnet standard 2.0, net461, net462, used to create microservices solutions on multiple platforms (runs on windows, linux, linux-arm [raspberry pi], and osx).
 
 # Advantages
 

--- a/commonWithDoc.props
+++ b/commonWithDoc.props
@@ -3,4 +3,8 @@
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net461'  Or '$(TargetFramework)' == 'net462'">
+    <DefineConstants>COMPATIBILITY</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/src/TWCore.Bot.Slack/TWCore.Bot.Slack.csproj
+++ b/src/TWCore.Bot.Slack/TWCore.Bot.Slack.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Bot.Slack</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Bot.Slack/TWCore.Bot.Slack.csproj
+++ b/src/TWCore.Bot.Slack/TWCore.Bot.Slack.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Bot.Slack</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Bot.Telegram/TWCore.Bot.Telegram.csproj
+++ b/src/TWCore.Bot.Telegram/TWCore.Bot.Telegram.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Bot.Telegram</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Bot.Telegram/TWCore.Bot.Telegram.csproj
+++ b/src/TWCore.Bot.Telegram/TWCore.Bot.Telegram.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Bot.Telegram</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Bot/TWCore.Bot.csproj
+++ b/src/TWCore.Bot/TWCore.Bot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Bot</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Bot/TWCore.Bot.csproj
+++ b/src/TWCore.Bot/TWCore.Bot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Bot</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Cache.Client/PoolAsyncItem.cs
+++ b/src/TWCore.Cache.Client/PoolAsyncItem.cs
@@ -225,7 +225,7 @@ namespace TWCore.Cache.Client
                     Core.Log.Write(ex);
                 }
             }
-            Core.Log.Warning("Ping Task for Pool item node: {0} was terminated.", Name);
+            Core.Log.InfoDetail("Ping Task for Pool item node: {0} was terminated.", Name);
         }
         #endregion
     }

--- a/src/TWCore.Cache.Client/TWCore.Cache.Client.csproj
+++ b/src/TWCore.Cache.Client/TWCore.Cache.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Cache.Client</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Cache.Client/TWCore.Cache.Client.csproj
+++ b/src/TWCore.Cache.Client/TWCore.Cache.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Cache.Client</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Cache.Server/TWCore.Cache.Server.csproj
+++ b/src/TWCore.Cache.Server/TWCore.Cache.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Cache.Server</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Cache.Server/TWCore.Cache.Server.csproj
+++ b/src/TWCore.Cache.Server/TWCore.Cache.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Cache.Server</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Cache/TWCore.Cache.csproj
+++ b/src/TWCore.Cache/TWCore.Cache.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Cache</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Cache/TWCore.Cache.csproj
+++ b/src/TWCore.Cache/TWCore.Cache.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Cache</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Collections/TWCore.Collections.csproj
+++ b/src/TWCore.Collections/TWCore.Collections.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Collections</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Collections/TWCore.Collections.csproj
+++ b/src/TWCore.Collections/TWCore.Collections.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Collections</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Data.MySql/TWCore.Data.MySql.csproj
+++ b/src/TWCore.Data.MySql/TWCore.Data.MySql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Data.MySql</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Data.MySql/TWCore.Data.MySql.csproj
+++ b/src/TWCore.Data.MySql/TWCore.Data.MySql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Data.MySql</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Data.PostgreSQL/TWCore.Data.PostgreSQL.csproj
+++ b/src/TWCore.Data.PostgreSQL/TWCore.Data.PostgreSQL.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Data.PostgreSQL</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Data.PostgreSQL/TWCore.Data.PostgreSQL.csproj
+++ b/src/TWCore.Data.PostgreSQL/TWCore.Data.PostgreSQL.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Data.PostgreSQL</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Data.SQLite/TWCore.Data.SQLite.csproj
+++ b/src/TWCore.Data.SQLite/TWCore.Data.SQLite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Data.SQLite</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Data.SQLite/TWCore.Data.SQLite.csproj
+++ b/src/TWCore.Data.SQLite/TWCore.Data.SQLite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Data.SQLite</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Data.SqlServer/TWCore.Data.SqlServer.csproj
+++ b/src/TWCore.Data.SqlServer/TWCore.Data.SqlServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Data.SqlServer</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Data.SqlServer/TWCore.Data.SqlServer.csproj
+++ b/src/TWCore.Data.SqlServer/TWCore.Data.SqlServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Data.SqlServer</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Data/TWCore.Data.csproj
+++ b/src/TWCore.Data/TWCore.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Data</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Data/TWCore.Data.csproj
+++ b/src/TWCore.Data/TWCore.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Data</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Geo/TWCore.Geo.csproj
+++ b/src/TWCore.Geo/TWCore.Geo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Geo</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Geo/TWCore.Geo.csproj
+++ b/src/TWCore.Geo/TWCore.Geo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Geo</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Messaging.NATS/NATSQueueClient.cs
+++ b/src/TWCore.Messaging.NATS/NATSQueueClient.cs
@@ -308,7 +308,11 @@ namespace TWCore.Messaging.NATS
         internal static byte[] CreateMessageBody(MultiArray<byte> message, Guid correlationId)
         {
             var body = new byte[16 + message.Count];
+#if NETSTANDARD2_0
+            correlationId.ToByteArray().CopyTo(body, 0);
+#else
             correlationId.TryWriteBytes(body.AsSpan(0, 16));
+#endif
             message.CopyTo(body, 16);
             return body;
         }
@@ -316,7 +320,11 @@ namespace TWCore.Messaging.NATS
         internal static (MultiArray<byte>, Guid) GetFromMessageBody(byte[] message)
         {
             var body = new MultiArray<byte>(message);
+#if NETSTANDARD2_0
+            var correlationId = new Guid(body.Slice(0, 16).ToArray());
+#else
             var correlationId = new Guid(body.Slice(0, 16).AsSpan());
+#endif
             var messageBody = body.Slice(16);
             return (messageBody, correlationId);
         }

--- a/src/TWCore.Messaging.NATS/NATSQueueClient.cs
+++ b/src/TWCore.Messaging.NATS/NATSQueueClient.cs
@@ -308,7 +308,7 @@ namespace TWCore.Messaging.NATS
         internal static byte[] CreateMessageBody(MultiArray<byte> message, Guid correlationId)
         {
             var body = new byte[16 + message.Count];
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             correlationId.ToByteArray().CopyTo(body, 0);
 #else
             correlationId.TryWriteBytes(body.AsSpan(0, 16));
@@ -320,7 +320,7 @@ namespace TWCore.Messaging.NATS
         internal static (MultiArray<byte>, Guid) GetFromMessageBody(byte[] message)
         {
             var body = new MultiArray<byte>(message);
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             var correlationId = new Guid(body.Slice(0, 16).ToArray());
 #else
             var correlationId = new Guid(body.Slice(0, 16).AsSpan());

--- a/src/TWCore.Messaging.NATS/NATSQueueRawClient.cs
+++ b/src/TWCore.Messaging.NATS/NATSQueueRawClient.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -290,7 +291,7 @@ namespace TWCore.Messaging.NATS
             var bodySpan = body.AsSpan();
 #if COMPATIBILITY
             correlationId.ToByteArray().CopyTo(body, 0);
-            BitConverter.GetBytes(nameLength).CopyTo(bodySpan.Slice(16, 4));
+            MemoryMarshal.Write(bodySpan.Slice(16, 4), ref nameLength);
             Encoding.GetBytes(name).CopyTo(bodySpan.Slice(20, nameLength));
 #else
             correlationId.TryWriteBytes(bodySpan.Slice(0, 16));

--- a/src/TWCore.Messaging.NATS/NATSQueueRawClient.cs
+++ b/src/TWCore.Messaging.NATS/NATSQueueRawClient.cs
@@ -288,9 +288,15 @@ namespace TWCore.Messaging.NATS
             var nameLength = Encoding.GetByteCount(name);
             var body = new byte[16 + 4 + nameLength + message.Count];
             var bodySpan = body.AsSpan();
+#if NETSTANDARD2_0
+            correlationId.ToByteArray().CopyTo(body, 0);
+            BitConverter.GetBytes(nameLength).CopyTo(bodySpan.Slice(16, 4));
+            Encoding.GetBytes(name).CopyTo(bodySpan.Slice(20, nameLength));
+#else
             correlationId.TryWriteBytes(bodySpan.Slice(0, 16));
             BitConverter.TryWriteBytes(bodySpan.Slice(16, 4), nameLength);
             Encoding.GetBytes(name, bodySpan.Slice(20, nameLength));
+#endif
             message.CopyTo(body, 20 + nameLength);
             return body;
         }
@@ -298,7 +304,11 @@ namespace TWCore.Messaging.NATS
         internal static (MultiArray<byte>, Guid, string) GetFromRawMessageBody(byte[] message)
         {
             var body = new MultiArray<byte>(message);
+#if NETSTANDARD2_0
+            var correlationId = new Guid(body.Slice(0, 16).ToArray());
+#else
             var correlationId = new Guid(body.Slice(0, 16).AsSpan());
+#endif
             var nameLength = BitConverter.ToInt32(message, 16);
             var name = Encoding.GetString(message, 20, nameLength);
             var messageBody = body.Slice(20 + nameLength);

--- a/src/TWCore.Messaging.NATS/NATSQueueRawClient.cs
+++ b/src/TWCore.Messaging.NATS/NATSQueueRawClient.cs
@@ -288,7 +288,7 @@ namespace TWCore.Messaging.NATS
             var nameLength = Encoding.GetByteCount(name);
             var body = new byte[16 + 4 + nameLength + message.Count];
             var bodySpan = body.AsSpan();
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             correlationId.ToByteArray().CopyTo(body, 0);
             BitConverter.GetBytes(nameLength).CopyTo(bodySpan.Slice(16, 4));
             Encoding.GetBytes(name).CopyTo(bodySpan.Slice(20, nameLength));
@@ -304,7 +304,7 @@ namespace TWCore.Messaging.NATS
         internal static (MultiArray<byte>, Guid, string) GetFromRawMessageBody(byte[] message)
         {
             var body = new MultiArray<byte>(message);
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             var correlationId = new Guid(body.Slice(0, 16).ToArray());
 #else
             var correlationId = new Guid(body.Slice(0, 16).AsSpan());

--- a/src/TWCore.Messaging.NATS/TWCore.Messaging.NATS.csproj
+++ b/src/TWCore.Messaging.NATS/TWCore.Messaging.NATS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Messaging.NATS</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Messaging.NATS/TWCore.Messaging.NATS.csproj
+++ b/src/TWCore.Messaging.NATS/TWCore.Messaging.NATS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Messaging.NATS</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Messaging.NSQ/NSQueueClient.cs
+++ b/src/TWCore.Messaging.NSQ/NSQueueClient.cs
@@ -304,7 +304,7 @@ namespace TWCore.Messaging.NSQ
         internal static byte[] CreateMessageBody(MultiArray<byte> message, Guid correlationId)
         {
             var body = new byte[16 + message.Count];
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             correlationId.ToByteArray().CopyTo(body, 0);
 #else
             correlationId.TryWriteBytes(body.AsSpan(0, 16));
@@ -316,7 +316,7 @@ namespace TWCore.Messaging.NSQ
         internal static (MultiArray<byte>, Guid) GetFromMessageBody(byte[] message)
         {
             var body = new MultiArray<byte>(message);
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             var correlationId = new Guid(body.Slice(0, 16).ToArray());
 #else
             var correlationId = new Guid(body.Slice(0, 16).AsSpan());

--- a/src/TWCore.Messaging.NSQ/NSQueueClient.cs
+++ b/src/TWCore.Messaging.NSQ/NSQueueClient.cs
@@ -304,7 +304,11 @@ namespace TWCore.Messaging.NSQ
         internal static byte[] CreateMessageBody(MultiArray<byte> message, Guid correlationId)
         {
             var body = new byte[16 + message.Count];
+#if NETSTANDARD2_0
+            correlationId.ToByteArray().CopyTo(body, 0);
+#else
             correlationId.TryWriteBytes(body.AsSpan(0, 16));
+#endif
             message.CopyTo(body, 16);
             return body;
         }
@@ -312,7 +316,11 @@ namespace TWCore.Messaging.NSQ
         internal static (MultiArray<byte>, Guid) GetFromMessageBody(byte[] message)
         {
             var body = new MultiArray<byte>(message);
+#if NETSTANDARD2_0
+            var correlationId = new Guid(body.Slice(0, 16).ToArray());
+#else
             var correlationId = new Guid(body.Slice(0, 16).AsSpan());
+#endif
             var messageBody = body.Slice(16);
             return (messageBody, correlationId);
         }

--- a/src/TWCore.Messaging.NSQ/NSQueueRawClient.cs
+++ b/src/TWCore.Messaging.NSQ/NSQueueRawClient.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -287,7 +288,7 @@ namespace TWCore.Messaging.NSQ
             var bodySpan = body.AsSpan();
 #if COMPATIBILITY
             correlationId.ToByteArray().CopyTo(body, 0);
-            BitConverter.GetBytes(nameLength).CopyTo(bodySpan.Slice(16, 4));
+            MemoryMarshal.Write(bodySpan.Slice(16, 4), ref nameLength);
             Encoding.GetBytes(name).CopyTo(bodySpan.Slice(20, nameLength));
 #else
             correlationId.TryWriteBytes(bodySpan.Slice(0, 16));

--- a/src/TWCore.Messaging.NSQ/NSQueueRawClient.cs
+++ b/src/TWCore.Messaging.NSQ/NSQueueRawClient.cs
@@ -285,9 +285,15 @@ namespace TWCore.Messaging.NSQ
             var nameLength = Encoding.GetByteCount(name);
             var body = new byte[16 + 4 + nameLength + message.Count];
             var bodySpan = body.AsSpan();
+#if NETSTANDARD2_0
+            correlationId.ToByteArray().CopyTo(body, 0);
+            BitConverter.GetBytes(nameLength).CopyTo(bodySpan.Slice(16, 4));
+            Encoding.GetBytes(name).CopyTo(bodySpan.Slice(20, nameLength));
+#else
             correlationId.TryWriteBytes(bodySpan.Slice(0, 16));
             BitConverter.TryWriteBytes(bodySpan.Slice(16, 4), nameLength);
             Encoding.GetBytes(name, bodySpan.Slice(20, nameLength));
+#endif
             message.CopyTo(body, 20 + nameLength);
             return body;
         }
@@ -295,7 +301,11 @@ namespace TWCore.Messaging.NSQ
         internal static (MultiArray<byte>, Guid, string) GetFromRawMessageBody(byte[] message)
         {
             var body = new MultiArray<byte>(message);
+#if NETSTANDARD2_0
+            var correlationId = new Guid(body.Slice(0, 16).ToArray());
+#else
             var correlationId = new Guid(body.Slice(0, 16).AsSpan());
+#endif
             var nameLength = BitConverter.ToInt32(message, 16);
             var name = Encoding.GetString(message, 20, nameLength);
             var messageBody = body.Slice(20 + nameLength);

--- a/src/TWCore.Messaging.NSQ/NSQueueRawClient.cs
+++ b/src/TWCore.Messaging.NSQ/NSQueueRawClient.cs
@@ -285,7 +285,7 @@ namespace TWCore.Messaging.NSQ
             var nameLength = Encoding.GetByteCount(name);
             var body = new byte[16 + 4 + nameLength + message.Count];
             var bodySpan = body.AsSpan();
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             correlationId.ToByteArray().CopyTo(body, 0);
             BitConverter.GetBytes(nameLength).CopyTo(bodySpan.Slice(16, 4));
             Encoding.GetBytes(name).CopyTo(bodySpan.Slice(20, nameLength));
@@ -301,7 +301,7 @@ namespace TWCore.Messaging.NSQ
         internal static (MultiArray<byte>, Guid, string) GetFromRawMessageBody(byte[] message)
         {
             var body = new MultiArray<byte>(message);
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             var correlationId = new Guid(body.Slice(0, 16).ToArray());
 #else
             var correlationId = new Guid(body.Slice(0, 16).AsSpan());

--- a/src/TWCore.Messaging.NSQ/TWCore.Messaging.NSQ.csproj
+++ b/src/TWCore.Messaging.NSQ/TWCore.Messaging.NSQ.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Messaging.NSQ</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Messaging.NSQ/TWCore.Messaging.NSQ.csproj
+++ b/src/TWCore.Messaging.NSQ/TWCore.Messaging.NSQ.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Messaging.NSQ</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Messaging.RabbitMQ/TWCore.Messaging.RabbitMQ.csproj
+++ b/src/TWCore.Messaging.RabbitMQ/TWCore.Messaging.RabbitMQ.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Messaging.RabbitMQ</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Messaging.RabbitMQ/TWCore.Messaging.RabbitMQ.csproj
+++ b/src/TWCore.Messaging.RabbitMQ/TWCore.Messaging.RabbitMQ.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Messaging.RabbitMQ</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Messaging/TWCore.Messaging.csproj
+++ b/src/TWCore.Messaging/TWCore.Messaging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Messaging</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Messaging/TWCore.Messaging.csproj
+++ b/src/TWCore.Messaging/TWCore.Messaging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Messaging</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Net.Browser/TWCore.Net.Browser.csproj
+++ b/src/TWCore.Net.Browser/TWCore.Net.Browser.csproj
@@ -8,6 +8,9 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <Reference Include="System.Net.Http">
+      <HintPath>..\..\..\..\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\Microsoft\Microsoft.NET.Build.Extensions\net461\lib\System.Net.Http.dll</HintPath>
+    </Reference>
   </ItemGroup>
+
 </Project>

--- a/src/TWCore.Net.Browser/TWCore.Net.Browser.csproj
+++ b/src/TWCore.Net.Browser/TWCore.Net.Browser.csproj
@@ -1,7 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Net.Browser</Title>
   </PropertyGroup>
+
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' ">
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+  </ItemGroup>
 </Project>

--- a/src/TWCore.Net.Browser/TWCore.Net.Browser.csproj
+++ b/src/TWCore.Net.Browser/TWCore.Net.Browser.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Net.Browser</Title>
   </PropertyGroup>
 </Project>

--- a/src/TWCore.Net.HttpServer/TWCore.Net.HttpServer.csproj
+++ b/src/TWCore.Net.HttpServer/TWCore.Net.HttpServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Net.HttpServer</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Net.HttpServer/TWCore.Net.HttpServer.csproj
+++ b/src/TWCore.Net.HttpServer/TWCore.Net.HttpServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Net.HttpServer</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Net.Rpc.Http/TWCore.Net.Rpc.Http.csproj
+++ b/src/TWCore.Net.Rpc.Http/TWCore.Net.Rpc.Http.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Net.Rpc.Http</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Net.Rpc.Http/TWCore.Net.Rpc.Http.csproj
+++ b/src/TWCore.Net.Rpc.Http/TWCore.Net.Rpc.Http.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Net.Rpc.Http</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Net.Rpc.Messaging/TWCore.Net.Rpc.Messaging.csproj
+++ b/src/TWCore.Net.Rpc.Messaging/TWCore.Net.Rpc.Messaging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Net.Rpc.Messaging</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Net.Rpc.Messaging/TWCore.Net.Rpc.Messaging.csproj
+++ b/src/TWCore.Net.Rpc.Messaging/TWCore.Net.Rpc.Messaging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Net.Rpc.Messaging</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Net.Rpc/TWCore.Net.Rpc.csproj
+++ b/src/TWCore.Net.Rpc/TWCore.Net.Rpc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Net.Rpc</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Net.Rpc/TWCore.Net.Rpc.csproj
+++ b/src/TWCore.Net.Rpc/TWCore.Net.Rpc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Net.Rpc</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Numerics/TWCore.Numerics.csproj
+++ b/src/TWCore.Numerics/TWCore.Numerics.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Numerics</Title>
   </PropertyGroup>
 </Project>

--- a/src/TWCore.Numerics/TWCore.Numerics.csproj
+++ b/src/TWCore.Numerics/TWCore.Numerics.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Numerics</Title>
   </PropertyGroup>
 </Project>

--- a/src/TWCore.Object/TWCore.Object.csproj
+++ b/src/TWCore.Object/TWCore.Object.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Object</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Object/TWCore.Object.csproj
+++ b/src/TWCore.Object/TWCore.Object.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Object</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Reflection/TWCore.Reflection.csproj
+++ b/src/TWCore.Reflection/TWCore.Reflection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Reflection</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Reflection/TWCore.Reflection.csproj
+++ b/src/TWCore.Reflection/TWCore.Reflection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Reflection</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Serialization.MsgPack/TWCore.Serialization.MsgPack.csproj
+++ b/src/TWCore.Serialization.MsgPack/TWCore.Serialization.MsgPack.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Serialization.MsgPack</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Serialization.MsgPack/TWCore.Serialization.MsgPack.csproj
+++ b/src/TWCore.Serialization.MsgPack/TWCore.Serialization.MsgPack.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Serialization.MsgPack</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Serialization.NSerializer/DeserializersTable.cs
+++ b/src/TWCore.Serialization.NSerializer/DeserializersTable.cs
@@ -841,6 +841,86 @@ namespace TWCore.Serialization.NSerializer
             return (byte)res;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected sbyte StreamReadSByte()
+        {
+            return (sbyte)Stream.ReadByte();
+        }
+
+#if NETSTANDARD2_0
+        byte[] _buffer = new byte[16];
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected ushort StreamReadUShort()
+        {
+            Stream.ReadExact(_buffer, 0, 2);
+            return BitConverter.ToUInt16(_buffer, 0);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected int StreamReadInt()
+        {
+            Stream.ReadExact(_buffer, 0, 4);
+            return BitConverter.ToInt32(_buffer, 0);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected double StreamReadDouble()
+        {
+            Stream.ReadExact(_buffer, 0, 8);
+            return BitConverter.ToDouble(_buffer, 0);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected float StreamReadFloat()
+        {
+            Stream.ReadExact(_buffer, 0, 4);
+            return BitConverter.ToSingle(_buffer, 0);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected long StreamReadLong()
+        {
+            Stream.ReadExact(_buffer, 0, 8);
+            return BitConverter.ToInt64(_buffer, 0);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected ulong StreamReadULong()
+        {
+            Stream.ReadExact(_buffer, 0, 8);
+            return BitConverter.ToUInt64(_buffer, 0);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected uint StreamReadUInt()
+        {
+            Stream.ReadExact(_buffer, 0, 4);
+            return BitConverter.ToUInt32(_buffer, 0);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected short StreamReadShort()
+        {
+            Stream.ReadExact(_buffer, 0, 2);
+            return BitConverter.ToInt16(_buffer, 0);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected char StreamReadChar()
+        {
+            Stream.ReadExact(_buffer, 0, 2);
+            return BitConverter.ToChar(_buffer, 0);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected decimal StreamReadDecimal()
+        {
+            Stream.ReadExact(_buffer, 0, 16);
+            var bits = new int[4];
+            for (var i = 0; i < 4; i++)
+                bits[i] = BitConverter.ToInt32(_buffer, i * 4);
+            return new decimal(bits);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected Guid StreamReadGuid()
+        {
+            Stream.ReadExact(_buffer, 0, 16);
+            return new Guid(_buffer.AsSpan(0, 16).ToArray());
+        }
+
+#else
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected ushort StreamReadUShort()
         {
             Span<byte> buffer = stackalloc byte[2];
@@ -914,17 +994,15 @@ namespace TWCore.Serialization.NSerializer
             return new decimal(bits);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected sbyte StreamReadSByte()
-        {
-            return (sbyte)Stream.ReadByte();
-        }
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected Guid StreamReadGuid()
         {
             Span<byte> buffer = stackalloc byte[16];
             Stream.Fill(buffer);
             return new Guid(buffer);
         }
+
+#endif
+
         #endregion
     }
 }

--- a/src/TWCore.Serialization.NSerializer/DeserializersTable.cs
+++ b/src/TWCore.Serialization.NSerializer/DeserializersTable.cs
@@ -846,7 +846,7 @@ namespace TWCore.Serialization.NSerializer
             return (sbyte)Stream.ReadByte();
         }
 
-#if NETSTANDARD2_0
+#if COMPATIBILITY
         byte[] _buffer = new byte[16];
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/TWCore.Serialization.NSerializer/SerializersTable.cs
+++ b/src/TWCore.Serialization.NSerializer/SerializersTable.cs
@@ -22,6 +22,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using TWCore.Reflection;
 // ReSharper disable UnusedMember.Local
 #pragma warning disable 1591
@@ -868,7 +869,7 @@ namespace TWCore.Serialization.NSerializer
             {
 #if COMPATIBILITY
                 _buffer[0] = DataBytesDefinition.RefObject;
-                BitConverter.GetBytes(oIdx).CopyTo(_buffer, 1);
+                MemoryMarshal.Write(_buffer.AsSpan(1), ref oIdx);
                 Stream.Write(_buffer, 0, 5);
 #else
                 Span<byte> buffer = stackalloc byte[5];
@@ -884,7 +885,7 @@ namespace TWCore.Serialization.NSerializer
             {
 #if COMPATIBILITY
                 _buffer[0] = DataBytesDefinition.RefType;
-                BitConverter.GetBytes(tIdx).CopyTo(_buffer, 1);
+                MemoryMarshal.Write(_buffer.AsSpan(1), ref tIdx);
                 Stream.Write(_buffer, 0, 5);
 #else
                 Span<byte> buffer = stackalloc byte[5];
@@ -918,7 +919,7 @@ namespace TWCore.Serialization.NSerializer
             {
 #if COMPATIBILITY
                 _buffer[0] = DataBytesDefinition.RefObject;
-                BitConverter.GetBytes(oIdx).CopyTo(_buffer, 1);
+                MemoryMarshal.Write(_buffer.AsSpan(1), ref oIdx);
                 Stream.Write(_buffer, 0, 5);
 #else
                 Span<byte> buffer = stackalloc byte[5];
@@ -934,7 +935,7 @@ namespace TWCore.Serialization.NSerializer
             {
 #if COMPATIBILITY
                 _buffer[0] = DataBytesDefinition.RefType;
-                BitConverter.GetBytes(tIdx).CopyTo(_buffer, 1);
+                MemoryMarshal.Write(_buffer.AsSpan(1), ref tIdx);
                 Stream.Write(_buffer, 0, 5);
 #else
                 Span<byte> buffer = stackalloc byte[5];
@@ -978,63 +979,63 @@ namespace TWCore.Serialization.NSerializer
         protected void WriteDefUshort(byte type, ushort value)
         {
             _buffer[0] = type;
-            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            MemoryMarshal.Write(_buffer.AsSpan(1), ref value);
             Stream.Write(_buffer, 0, 3);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDefInt(byte type, int value)
         {
             _buffer[0] = type;
-            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            MemoryMarshal.Write(_buffer.AsSpan(1), ref value);
             Stream.Write(_buffer, 0, 5);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDefDouble(byte type, double value)
         {
             _buffer[0] = type;
-            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            MemoryMarshal.Write(_buffer.AsSpan(1), ref value);
             Stream.Write(_buffer, 0, 9);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDefFloat(byte type, float value)
         {
             _buffer[0] = type;
-            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            MemoryMarshal.Write(_buffer.AsSpan(1), ref value);
             Stream.Write(_buffer, 0, 5);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDefLong(byte type, long value)
         {
             _buffer[0] = type;
-            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            MemoryMarshal.Write(_buffer.AsSpan(1), ref value);
             Stream.Write(_buffer, 0, 9);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDefULong(byte type, ulong value)
         {
             _buffer[0] = type;
-            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            MemoryMarshal.Write(_buffer.AsSpan(1), ref value);
             Stream.Write(_buffer, 0, 9);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDefUInt(byte type, uint value)
         {
             _buffer[0] = type;
-            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            MemoryMarshal.Write(_buffer.AsSpan(1), ref value);
             Stream.Write(_buffer, 0, 5);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDefShort(byte type, short value)
         {
             _buffer[0] = type;
-            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            MemoryMarshal.Write(_buffer.AsSpan(1), ref value);
             Stream.Write(_buffer, 0, 3);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDefChar(byte type, char value)
         {
             _buffer[0] = type;
-            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            MemoryMarshal.Write(_buffer.AsSpan(1), ref value);
             Stream.Write(_buffer, 0, 3);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1043,61 +1044,61 @@ namespace TWCore.Serialization.NSerializer
             _buffer[0] = type;
             var bits = decimal.GetBits(value);
             for (var i = 0; i < 4; i++)
-                BitConverter.GetBytes(bits[i]).CopyTo(_buffer, (i * 4) + 1);
+                MemoryMarshal.Write(_buffer.AsSpan((i * 4) + 1), ref bits[i]);
             Stream.Write(_buffer, 0, 17);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteUshort(ushort value)
         {
-            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            MemoryMarshal.Write(_buffer, ref value);
             Stream.Write(_buffer, 0, 2);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteInt(int value)
         {
-            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            MemoryMarshal.Write(_buffer, ref value);
             Stream.Write(_buffer, 0, 4);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDouble(double value)
         {
-            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            MemoryMarshal.Write(_buffer, ref value);
             Stream.Write(_buffer, 0, 8);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteFloat(float value)
         {
-            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            MemoryMarshal.Write(_buffer, ref value);
             Stream.Write(_buffer, 0, 4);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteLong(long value)
         {
-            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            MemoryMarshal.Write(_buffer, ref value);
             Stream.Write(_buffer, 0, 8);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteULong(ulong value)
         {
-            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            MemoryMarshal.Write(_buffer, ref value);
             Stream.Write(_buffer, 0, 8);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteUInt(uint value)
         {
-            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            MemoryMarshal.Write(_buffer, ref value);
             Stream.Write(_buffer, 0, 4);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteShort(short value)
         {
-            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            MemoryMarshal.Write(_buffer, ref value);
             Stream.Write(_buffer, 0, 2);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteChar(char value)
         {
-            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            MemoryMarshal.Write(_buffer, ref value);
             Stream.Write(_buffer, 0, 2);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1105,14 +1106,13 @@ namespace TWCore.Serialization.NSerializer
         {
             var bits = decimal.GetBits(value);
             for (var i = 0; i < 4; i++)
-                BitConverter.GetBytes(bits[i]).CopyTo(_buffer, i * 4);
+                MemoryMarshal.Write(_buffer.AsSpan(i * 4), ref bits[i]);
             Stream.Write(_buffer, 0, 16);
-
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteSByte(sbyte value)
         {
-            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            MemoryMarshal.Write(_buffer, ref value);
             Stream.Write(_buffer, 0, 1);
         }
 #else

--- a/src/TWCore.Serialization.NSerializer/SerializersTable.cs
+++ b/src/TWCore.Serialization.NSerializer/SerializersTable.cs
@@ -866,7 +866,7 @@ namespace TWCore.Serialization.NSerializer
             }
             if (_objectCache.TryGetValue(value, out var oIdx))
             {
-#if NETSTANDARD2_0
+#if COMPATIBILITY
                 _buffer[0] = DataBytesDefinition.RefObject;
                 BitConverter.GetBytes(oIdx).CopyTo(_buffer, 1);
                 Stream.Write(_buffer, 0, 5);
@@ -882,7 +882,7 @@ namespace TWCore.Serialization.NSerializer
             var descriptor = Descriptors.GetOrAdd(vType, type => new SerializerTypeDescriptor(type));
             if (_typeCache.TryGetValue(vType, out var tIdx))
             {
-#if NETSTANDARD2_0
+#if COMPATIBILITY
                 _buffer[0] = DataBytesDefinition.RefType;
                 BitConverter.GetBytes(tIdx).CopyTo(_buffer, 1);
                 Stream.Write(_buffer, 0, 5);
@@ -916,7 +916,7 @@ namespace TWCore.Serialization.NSerializer
             var vType = value.GetType();
             if (_objectCache.TryGetValue(value, out var oIdx))
             {
-#if NETSTANDARD2_0
+#if COMPATIBILITY
                 _buffer[0] = DataBytesDefinition.RefObject;
                 BitConverter.GetBytes(oIdx).CopyTo(_buffer, 1);
                 Stream.Write(_buffer, 0, 5);
@@ -932,7 +932,7 @@ namespace TWCore.Serialization.NSerializer
             var descriptor = Descriptors.GetOrAdd(vType, type => new SerializerTypeDescriptor(type));
             if (_typeCache.TryGetValue(vType, out var tIdx))
             {
-#if NETSTANDARD2_0
+#if COMPATIBILITY
                 _buffer[0] = DataBytesDefinition.RefType;
                 BitConverter.GetBytes(tIdx).CopyTo(_buffer, 1);
                 Stream.Write(_buffer, 0, 5);
@@ -963,7 +963,7 @@ namespace TWCore.Serialization.NSerializer
             Stream.WriteByte(value);
         }
 
-#if NETSTANDARD2_0
+#if COMPATIBILITY
         byte[] _buffer = new byte[17];
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/TWCore.Serialization.NSerializer/SerializersTable.cs
+++ b/src/TWCore.Serialization.NSerializer/SerializersTable.cs
@@ -866,20 +866,32 @@ namespace TWCore.Serialization.NSerializer
             }
             if (_objectCache.TryGetValue(value, out var oIdx))
             {
+#if NETSTANDARD2_0
+                _buffer[0] = DataBytesDefinition.RefObject;
+                BitConverter.GetBytes(oIdx).CopyTo(_buffer, 1);
+                Stream.Write(_buffer, 0, 5);
+#else
                 Span<byte> buffer = stackalloc byte[5];
                 buffer[0] = DataBytesDefinition.RefObject;
                 BitConverter.TryWriteBytes(buffer.Slice(1), oIdx);
                 Stream.Write(buffer);
+#endif
                 return;
             }
             _objectCache.Set(value);
             var descriptor = Descriptors.GetOrAdd(vType, type => new SerializerTypeDescriptor(type));
             if (_typeCache.TryGetValue(vType, out var tIdx))
             {
+#if NETSTANDARD2_0
+                _buffer[0] = DataBytesDefinition.RefType;
+                BitConverter.GetBytes(tIdx).CopyTo(_buffer, 1);
+                Stream.Write(_buffer, 0, 5);
+#else
                 Span<byte> buffer = stackalloc byte[5];
                 buffer[0] = DataBytesDefinition.RefType;
                 BitConverter.TryWriteBytes(buffer.Slice(1), tIdx);
                 Stream.Write(buffer);
+#endif
             }
             else
             {
@@ -904,20 +916,32 @@ namespace TWCore.Serialization.NSerializer
             var vType = value.GetType();
             if (_objectCache.TryGetValue(value, out var oIdx))
             {
+#if NETSTANDARD2_0
+                _buffer[0] = DataBytesDefinition.RefObject;
+                BitConverter.GetBytes(oIdx).CopyTo(_buffer, 1);
+                Stream.Write(_buffer, 0, 5);
+#else
                 Span<byte> buffer = stackalloc byte[5];
                 buffer[0] = DataBytesDefinition.RefObject;
                 BitConverter.TryWriteBytes(buffer.Slice(1), oIdx);
                 Stream.Write(buffer);
+#endif
                 return;
             }
             _objectCache.Set(value);
             var descriptor = Descriptors.GetOrAdd(vType, type => new SerializerTypeDescriptor(type));
             if (_typeCache.TryGetValue(vType, out var tIdx))
             {
+#if NETSTANDARD2_0
+                _buffer[0] = DataBytesDefinition.RefType;
+                BitConverter.GetBytes(tIdx).CopyTo(_buffer, 1);
+                Stream.Write(_buffer, 0, 5);
+#else
                 Span<byte> buffer = stackalloc byte[5];
                 buffer[0] = DataBytesDefinition.RefType;
                 BitConverter.TryWriteBytes(buffer.Slice(1), tIdx);
                 Stream.Write(buffer);
+#endif
             }
             else
             {
@@ -934,6 +958,165 @@ namespace TWCore.Serialization.NSerializer
 
         #region Private Write Methods
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteByte(byte value)
+        {
+            Stream.WriteByte(value);
+        }
+
+#if NETSTANDARD2_0
+        byte[] _buffer = new byte[17];
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefByte(byte type, byte value)
+        {
+            _buffer[0] = type;
+            _buffer[1] = value;
+            Stream.Write(_buffer, 0, 2);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefUshort(byte type, ushort value)
+        {
+            _buffer[0] = type;
+            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            Stream.Write(_buffer, 0, 3);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefInt(byte type, int value)
+        {
+            _buffer[0] = type;
+            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            Stream.Write(_buffer, 0, 5);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefDouble(byte type, double value)
+        {
+            _buffer[0] = type;
+            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            Stream.Write(_buffer, 0, 9);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefFloat(byte type, float value)
+        {
+            _buffer[0] = type;
+            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            Stream.Write(_buffer, 0, 5);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefLong(byte type, long value)
+        {
+            _buffer[0] = type;
+            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            Stream.Write(_buffer, 0, 9);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefULong(byte type, ulong value)
+        {
+            _buffer[0] = type;
+            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            Stream.Write(_buffer, 0, 9);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefUInt(byte type, uint value)
+        {
+            _buffer[0] = type;
+            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            Stream.Write(_buffer, 0, 5);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefShort(byte type, short value)
+        {
+            _buffer[0] = type;
+            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            Stream.Write(_buffer, 0, 3);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefChar(byte type, char value)
+        {
+            _buffer[0] = type;
+            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            Stream.Write(_buffer, 0, 3);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefDecimal(byte type, decimal value)
+        {
+            _buffer[0] = type;
+            var bits = decimal.GetBits(value);
+            for (var i = 0; i < 4; i++)
+                BitConverter.GetBytes(bits[i]).CopyTo(_buffer, (i * 4) + 1);
+            Stream.Write(_buffer, 0, 17);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteUshort(ushort value)
+        {
+            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            Stream.Write(_buffer, 0, 2);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteInt(int value)
+        {
+            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            Stream.Write(_buffer, 0, 4);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDouble(double value)
+        {
+            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            Stream.Write(_buffer, 0, 8);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteFloat(float value)
+        {
+            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            Stream.Write(_buffer, 0, 4);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteLong(long value)
+        {
+            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            Stream.Write(_buffer, 0, 8);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteULong(ulong value)
+        {
+            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            Stream.Write(_buffer, 0, 8);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteUInt(uint value)
+        {
+            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            Stream.Write(_buffer, 0, 4);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteShort(short value)
+        {
+            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            Stream.Write(_buffer, 0, 2);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteChar(char value)
+        {
+            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            Stream.Write(_buffer, 0, 2);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDecimal(decimal value)
+        {
+            var bits = decimal.GetBits(value);
+            for (var i = 0; i < 4; i++)
+                BitConverter.GetBytes(bits[i]).CopyTo(_buffer, i * 4);
+            Stream.Write(_buffer, 0, 16);
+
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteSByte(sbyte value)
+        {
+            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            Stream.Write(_buffer, 0, 1);
+        }
+#else
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDefByte(byte type, byte value)
         {
             Span<byte> buffer = stackalloc byte[2];
@@ -941,6 +1124,7 @@ namespace TWCore.Serialization.NSerializer
             buffer[1] = value;
             Stream.Write(buffer);
         }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDefUshort(byte type, ushort value)
         {
@@ -1025,11 +1209,6 @@ namespace TWCore.Serialization.NSerializer
             Stream.Write(buffer);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected void WriteByte(byte value)
-        {
-            Stream.WriteByte(value);
-        }
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteUshort(ushort value)
         {
             Span<byte> buffer = stackalloc byte[2];
@@ -1108,6 +1287,8 @@ namespace TWCore.Serialization.NSerializer
             BitConverter.TryWriteBytes(buffer, value);
             Stream.Write(buffer);
         }
+#endif
+
         #endregion
     }
 }

--- a/src/TWCore.Serialization.NSerializer/TWCore.Serialization.NSerializer.csproj
+++ b/src/TWCore.Serialization.NSerializer/TWCore.Serialization.NSerializer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Serialization.NSerializer</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Serialization.NSerializer/TWCore.Serialization.NSerializer.csproj
+++ b/src/TWCore.Serialization.NSerializer/TWCore.Serialization.NSerializer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Serialization.NSerializer</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Serialization.NSerializer/Types/GuidSerializer.cs
+++ b/src/TWCore.Serialization.NSerializer/Types/GuidSerializer.cs
@@ -32,7 +32,7 @@ namespace TWCore.Serialization.NSerializer
                 WriteDefInt(DataBytesDefinition.RefGuid, objIdx);
             else
             {
-#if NETSTANDARD2_0
+#if COMPATIBILITY
                 var bytes = new byte[17];
                 bytes[0] = DataBytesDefinition.Guid;
                 value.ToByteArray().CopyTo(bytes, 1);

--- a/src/TWCore.Serialization.NSerializer/Types/GuidSerializer.cs
+++ b/src/TWCore.Serialization.NSerializer/Types/GuidSerializer.cs
@@ -32,9 +32,15 @@ namespace TWCore.Serialization.NSerializer
                 WriteDefInt(DataBytesDefinition.RefGuid, objIdx);
             else
             {
+#if NETSTANDARD2_0
+                var bytes = new byte[17];
+                bytes[0] = DataBytesDefinition.Guid;
+                value.ToByteArray().CopyTo(bytes, 1);
+#else
                 Span<byte> bytes = stackalloc byte[17];
                 bytes[0] = DataBytesDefinition.Guid;
                 value.TryWriteBytes(bytes.Slice(1));
+#endif
                 Stream.Write(bytes);
                 _guidCache.Set(value);
             }

--- a/src/TWCore.Serialization.NSerializer/Types/StringSerializer.cs
+++ b/src/TWCore.Serialization.NSerializer/Types/StringSerializer.cs
@@ -75,7 +75,7 @@ namespace TWCore.Serialization.NSerializer
                 }
             }
 
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             var length = Encoding.UTF8.GetByteCount(value);
 
             var bufferLength = length + 5;
@@ -149,7 +149,7 @@ namespace TWCore.Serialization.NSerializer
 
             string strValue = null;
 
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             var buffer = ArrayPool<byte>.Shared.Rent(length);
             try
             {

--- a/src/TWCore.Serialization.NSerializer/Types/StringSerializer.cs
+++ b/src/TWCore.Serialization.NSerializer/Types/StringSerializer.cs
@@ -17,6 +17,7 @@ limitations under the License.
 using System;
 using System.Buffers;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 #pragma warning disable 1591
 
@@ -82,7 +83,7 @@ namespace TWCore.Serialization.NSerializer
             var buffer = ArrayPool<byte>.Shared.Rent(bufferLength);
             var bufferSpan = buffer.AsSpan(0, bufferLength);
             buffer[0] = DataBytesDefinition.StringLength;
-            BitConverter.GetBytes(length).CopyTo(bufferSpan.Slice(1, 4));
+            MemoryMarshal.Write(bufferSpan.Slice(1, 4), ref length);
             Encoding.UTF8.GetBytes(value, 0, value.Length, buffer, 5);
             Stream.Write(buffer, 0, bufferLength);
             ArrayPool<byte>.Shared.Return(buffer);

--- a/src/TWCore.Serialization.NSerializer/Types/StringSerializer.cs
+++ b/src/TWCore.Serialization.NSerializer/Types/StringSerializer.cs
@@ -75,6 +75,18 @@ namespace TWCore.Serialization.NSerializer
                 }
             }
 
+#if NETSTANDARD2_0
+            var length = Encoding.UTF8.GetByteCount(value);
+
+            var bufferLength = length + 5;
+            var buffer = ArrayPool<byte>.Shared.Rent(bufferLength);
+            var bufferSpan = buffer.AsSpan(0, bufferLength);
+            buffer[0] = DataBytesDefinition.StringLength;
+            BitConverter.GetBytes(length).CopyTo(bufferSpan.Slice(1, 4));
+            Encoding.UTF8.GetBytes(value, 0, value.Length, buffer, 5);
+            Stream.Write(buffer, 0, bufferLength);
+            ArrayPool<byte>.Shared.Return(buffer);
+#else
             var length = Encoding.UTF8.GetByteCount(value);
             if (length <= 16384)
             {
@@ -94,6 +106,7 @@ namespace TWCore.Serialization.NSerializer
                 Stream.Write(bufferSpan);
                 ArrayPool<byte>.Shared.Return(buffer);
             }
+#endif
         }
     }
 
@@ -136,6 +149,22 @@ namespace TWCore.Serialization.NSerializer
 
             string strValue = null;
 
+#if NETSTANDARD2_0
+            var buffer = ArrayPool<byte>.Shared.Rent(length);
+            try
+            {
+                Stream.ReadExact(buffer, 0, length);
+                strValue = Encoding.UTF8.GetString(buffer, 0, length);
+            }
+            catch
+            {
+                throw;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+#else
             if (length <= 16384)
             {
                 Span<byte> bufferSpan = stackalloc byte[length];
@@ -159,6 +188,7 @@ namespace TWCore.Serialization.NSerializer
                     ArrayPool<byte>.Shared.Return(buffer);
                 }
             }
+#endif
 
             var sLength = strValue.Length;
 

--- a/src/TWCore.Serialization.PWSerializer/TWCore.Serialization.PWSerializer.csproj
+++ b/src/TWCore.Serialization.PWSerializer/TWCore.Serialization.PWSerializer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Serialization.PWSerializer</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Serialization.PWSerializer/TWCore.Serialization.PWSerializer.csproj
+++ b/src/TWCore.Serialization.PWSerializer/TWCore.Serialization.PWSerializer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Serialization.PWSerializer</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Serialization.RawSerializer/DeserializersTable.cs
+++ b/src/TWCore.Serialization.RawSerializer/DeserializersTable.cs
@@ -806,7 +806,93 @@ namespace TWCore.Serialization.RawSerializer
 
         #region Private Read Methods
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected byte StreamReadByte() => (byte)Stream.ReadByte();
+        protected byte StreamReadByte()
+        {
+            var res = Stream.ReadByte();
+            if (res == -1)
+                throw new IOException("The stream has been closed.");
+            return (byte)res;
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected sbyte StreamReadSByte()
+        {
+            return (sbyte)Stream.ReadByte();
+        }
+
+#if NETSTANDARD2_0
+        byte[] _buffer = new byte[16];
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected ushort StreamReadUShort()
+        {
+            Stream.ReadExact(_buffer, 0, 2);
+            return BitConverter.ToUInt16(_buffer, 0);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected int StreamReadInt()
+        {
+            Stream.ReadExact(_buffer, 0, 4);
+            return BitConverter.ToInt32(_buffer, 0);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected double StreamReadDouble()
+        {
+            Stream.ReadExact(_buffer, 0, 8);
+            return BitConverter.ToDouble(_buffer, 0);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected float StreamReadFloat()
+        {
+            Stream.ReadExact(_buffer, 0, 4);
+            return BitConverter.ToSingle(_buffer, 0);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected long StreamReadLong()
+        {
+            Stream.ReadExact(_buffer, 0, 8);
+            return BitConverter.ToInt64(_buffer, 0);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected ulong StreamReadULong()
+        {
+            Stream.ReadExact(_buffer, 0, 8);
+            return BitConverter.ToUInt64(_buffer, 0);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected uint StreamReadUInt()
+        {
+            Stream.ReadExact(_buffer, 0, 4);
+            return BitConverter.ToUInt32(_buffer, 0);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected short StreamReadShort()
+        {
+            Stream.ReadExact(_buffer, 0, 2);
+            return BitConverter.ToInt16(_buffer, 0);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected char StreamReadChar()
+        {
+            Stream.ReadExact(_buffer, 0, 2);
+            return BitConverter.ToChar(_buffer, 0);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected decimal StreamReadDecimal()
+        {
+            Stream.ReadExact(_buffer, 0, 16);
+            var bits = new int[4];
+            for (var i = 0; i < 4; i++)
+                bits[i] = BitConverter.ToInt32(_buffer, i * 4);
+            return new decimal(bits);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected Guid StreamReadGuid()
+        {
+            Stream.ReadExact(_buffer, 0, 16);
+            return new Guid(_buffer.AsSpan(0, 16).ToArray());
+        }
+
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected ushort StreamReadUShort()
         {
@@ -876,14 +962,9 @@ namespace TWCore.Serialization.RawSerializer
             Span<byte> buffer = stackalloc byte[16];
             Stream.Fill(buffer);
             var bits = new int[4];
-            for(var i = 0; i < 4; i++)
+            for (var i = 0; i < 4; i++)
                 bits[i] = BitConverter.ToInt32(buffer.Slice(i * 4, 4));
             return new decimal(bits);
-        }
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected sbyte StreamReadSByte()
-        {
-            return (sbyte)Stream.ReadByte();
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected Guid StreamReadGuid()
@@ -892,6 +973,9 @@ namespace TWCore.Serialization.RawSerializer
             Stream.Fill(buffer);
             return new Guid(buffer);
         }
+
+#endif
+
         #endregion
     }
 }

--- a/src/TWCore.Serialization.RawSerializer/DeserializersTable.cs
+++ b/src/TWCore.Serialization.RawSerializer/DeserializersTable.cs
@@ -819,7 +819,7 @@ namespace TWCore.Serialization.RawSerializer
             return (sbyte)Stream.ReadByte();
         }
 
-#if NETSTANDARD2_0
+#if COMPATIBILITY
         byte[] _buffer = new byte[16];
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/TWCore.Serialization.RawSerializer/SerializersTable.cs
+++ b/src/TWCore.Serialization.RawSerializer/SerializersTable.cs
@@ -839,20 +839,32 @@ namespace TWCore.Serialization.RawSerializer
             }
             if (_objectCache.TryGetValue(value, out var oIdx))
             {
+#if NETSTANDARD2_0
+                _buffer[0] = DataBytesDefinition.RefObject;
+                BitConverter.GetBytes(oIdx).CopyTo(_buffer, 1);
+                Stream.Write(_buffer, 0, 5);
+#else
                 Span<byte> buffer = stackalloc byte[5];
                 buffer[0] = DataBytesDefinition.RefObject;
                 BitConverter.TryWriteBytes(buffer.Slice(1), oIdx);
                 Stream.Write(buffer);
+#endif
                 return;
             }
             _objectCache.Set(value);
             var descriptor = Descriptors.GetOrAdd(vType, type => new SerializerTypeDescriptor(type));
             if (_typeCache.TryGetValue(vType, out var tIdx))
             {
+#if NETSTANDARD2_0
+                _buffer[0] = DataBytesDefinition.RefType;
+                BitConverter.GetBytes(tIdx).CopyTo(_buffer, 1);
+                Stream.Write(_buffer, 0, 5);
+#else
                 Span<byte> buffer = stackalloc byte[5];
                 buffer[0] = DataBytesDefinition.RefType;
                 BitConverter.TryWriteBytes(buffer.Slice(1), tIdx);
                 Stream.Write(buffer);
+#endif
             }
             else
             {
@@ -877,20 +889,32 @@ namespace TWCore.Serialization.RawSerializer
             var vType = value.GetType();
             if (_objectCache.TryGetValue(value, out var oIdx))
             {
+#if NETSTANDARD2_0
+                _buffer[0] = DataBytesDefinition.RefObject;
+                BitConverter.GetBytes(oIdx).CopyTo(_buffer, 1);
+                Stream.Write(_buffer, 0, 5);
+#else
                 Span<byte> buffer = stackalloc byte[5];
                 buffer[0] = DataBytesDefinition.RefObject;
                 BitConverter.TryWriteBytes(buffer.Slice(1), oIdx);
                 Stream.Write(buffer);
+#endif
                 return;
             }
             _objectCache.Set(value);
             var descriptor = Descriptors.GetOrAdd(vType, type => new SerializerTypeDescriptor(type));
             if (_typeCache.TryGetValue(vType, out var tIdx))
             {
+#if NETSTANDARD2_0
+                _buffer[0] = DataBytesDefinition.RefType;
+                BitConverter.GetBytes(tIdx).CopyTo(_buffer, 1);
+                Stream.Write(_buffer, 0, 5);
+#else
                 Span<byte> buffer = stackalloc byte[5];
                 buffer[0] = DataBytesDefinition.RefType;
                 BitConverter.TryWriteBytes(buffer.Slice(1), tIdx);
                 Stream.Write(buffer);
+#endif
             }
             else
             {
@@ -907,6 +931,165 @@ namespace TWCore.Serialization.RawSerializer
 
         #region Private Write Methods
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteByte(byte value)
+        {
+            Stream.WriteByte(value);
+        }
+
+#if NETSTANDARD2_0
+        byte[] _buffer = new byte[17];
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefByte(byte type, byte value)
+        {
+            _buffer[0] = type;
+            _buffer[1] = value;
+            Stream.Write(_buffer, 0, 2);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefUshort(byte type, ushort value)
+        {
+            _buffer[0] = type;
+            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            Stream.Write(_buffer, 0, 3);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefInt(byte type, int value)
+        {
+            _buffer[0] = type;
+            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            Stream.Write(_buffer, 0, 5);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefDouble(byte type, double value)
+        {
+            _buffer[0] = type;
+            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            Stream.Write(_buffer, 0, 9);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefFloat(byte type, float value)
+        {
+            _buffer[0] = type;
+            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            Stream.Write(_buffer, 0, 5);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefLong(byte type, long value)
+        {
+            _buffer[0] = type;
+            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            Stream.Write(_buffer, 0, 9);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefULong(byte type, ulong value)
+        {
+            _buffer[0] = type;
+            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            Stream.Write(_buffer, 0, 9);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefUInt(byte type, uint value)
+        {
+            _buffer[0] = type;
+            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            Stream.Write(_buffer, 0, 5);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefShort(byte type, short value)
+        {
+            _buffer[0] = type;
+            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            Stream.Write(_buffer, 0, 3);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefChar(byte type, char value)
+        {
+            _buffer[0] = type;
+            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            Stream.Write(_buffer, 0, 3);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDefDecimal(byte type, decimal value)
+        {
+            _buffer[0] = type;
+            var bits = decimal.GetBits(value);
+            for (var i = 0; i < 4; i++)
+                BitConverter.GetBytes(bits[i]).CopyTo(_buffer, (i * 4) + 1);
+            Stream.Write(_buffer, 0, 17);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteUshort(ushort value)
+        {
+            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            Stream.Write(_buffer, 0, 2);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteInt(int value)
+        {
+            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            Stream.Write(_buffer, 0, 4);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDouble(double value)
+        {
+            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            Stream.Write(_buffer, 0, 8);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteFloat(float value)
+        {
+            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            Stream.Write(_buffer, 0, 4);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteLong(long value)
+        {
+            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            Stream.Write(_buffer, 0, 8);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteULong(ulong value)
+        {
+            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            Stream.Write(_buffer, 0, 8);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteUInt(uint value)
+        {
+            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            Stream.Write(_buffer, 0, 4);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteShort(short value)
+        {
+            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            Stream.Write(_buffer, 0, 2);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteChar(char value)
+        {
+            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            Stream.Write(_buffer, 0, 2);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteDecimal(decimal value)
+        {
+            var bits = decimal.GetBits(value);
+            for (var i = 0; i < 4; i++)
+                BitConverter.GetBytes(bits[i]).CopyTo(_buffer, i * 4);
+            Stream.Write(_buffer, 0, 16);
+
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void WriteSByte(sbyte value)
+        {
+            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            Stream.Write(_buffer, 0, 1);
+        }
+#else
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDefByte(byte type, byte value)
         {
             Span<byte> buffer = stackalloc byte[2];
@@ -914,6 +1097,7 @@ namespace TWCore.Serialization.RawSerializer
             buffer[1] = value;
             Stream.Write(buffer);
         }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDefUshort(byte type, ushort value)
         {
@@ -998,11 +1182,6 @@ namespace TWCore.Serialization.RawSerializer
             Stream.Write(buffer);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected void WriteByte(byte value)
-        {
-            Stream.WriteByte(value);
-        }
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteUshort(ushort value)
         {
             Span<byte> buffer = stackalloc byte[2];
@@ -1081,6 +1260,8 @@ namespace TWCore.Serialization.RawSerializer
             BitConverter.TryWriteBytes(buffer, value);
             Stream.Write(buffer);
         }
+#endif
+
         #endregion
     }
 }

--- a/src/TWCore.Serialization.RawSerializer/SerializersTable.cs
+++ b/src/TWCore.Serialization.RawSerializer/SerializersTable.cs
@@ -839,7 +839,7 @@ namespace TWCore.Serialization.RawSerializer
             }
             if (_objectCache.TryGetValue(value, out var oIdx))
             {
-#if NETSTANDARD2_0
+#if COMPATIBILITY
                 _buffer[0] = DataBytesDefinition.RefObject;
                 BitConverter.GetBytes(oIdx).CopyTo(_buffer, 1);
                 Stream.Write(_buffer, 0, 5);
@@ -855,7 +855,7 @@ namespace TWCore.Serialization.RawSerializer
             var descriptor = Descriptors.GetOrAdd(vType, type => new SerializerTypeDescriptor(type));
             if (_typeCache.TryGetValue(vType, out var tIdx))
             {
-#if NETSTANDARD2_0
+#if COMPATIBILITY
                 _buffer[0] = DataBytesDefinition.RefType;
                 BitConverter.GetBytes(tIdx).CopyTo(_buffer, 1);
                 Stream.Write(_buffer, 0, 5);
@@ -889,7 +889,7 @@ namespace TWCore.Serialization.RawSerializer
             var vType = value.GetType();
             if (_objectCache.TryGetValue(value, out var oIdx))
             {
-#if NETSTANDARD2_0
+#if COMPATIBILITY
                 _buffer[0] = DataBytesDefinition.RefObject;
                 BitConverter.GetBytes(oIdx).CopyTo(_buffer, 1);
                 Stream.Write(_buffer, 0, 5);
@@ -905,7 +905,7 @@ namespace TWCore.Serialization.RawSerializer
             var descriptor = Descriptors.GetOrAdd(vType, type => new SerializerTypeDescriptor(type));
             if (_typeCache.TryGetValue(vType, out var tIdx))
             {
-#if NETSTANDARD2_0
+#if COMPATIBILITY
                 _buffer[0] = DataBytesDefinition.RefType;
                 BitConverter.GetBytes(tIdx).CopyTo(_buffer, 1);
                 Stream.Write(_buffer, 0, 5);
@@ -936,7 +936,7 @@ namespace TWCore.Serialization.RawSerializer
             Stream.WriteByte(value);
         }
 
-#if NETSTANDARD2_0
+#if COMPATIBILITY
         byte[] _buffer = new byte[17];
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/TWCore.Serialization.RawSerializer/SerializersTable.cs
+++ b/src/TWCore.Serialization.RawSerializer/SerializersTable.cs
@@ -22,6 +22,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using TWCore.Reflection;
 #pragma warning disable 1591
 
@@ -841,7 +842,7 @@ namespace TWCore.Serialization.RawSerializer
             {
 #if COMPATIBILITY
                 _buffer[0] = DataBytesDefinition.RefObject;
-                BitConverter.GetBytes(oIdx).CopyTo(_buffer, 1);
+                MemoryMarshal.Write(_buffer.AsSpan(1), ref oIdx);
                 Stream.Write(_buffer, 0, 5);
 #else
                 Span<byte> buffer = stackalloc byte[5];
@@ -857,7 +858,7 @@ namespace TWCore.Serialization.RawSerializer
             {
 #if COMPATIBILITY
                 _buffer[0] = DataBytesDefinition.RefType;
-                BitConverter.GetBytes(tIdx).CopyTo(_buffer, 1);
+                MemoryMarshal.Write(_buffer.AsSpan(1), ref tIdx);
                 Stream.Write(_buffer, 0, 5);
 #else
                 Span<byte> buffer = stackalloc byte[5];
@@ -891,7 +892,7 @@ namespace TWCore.Serialization.RawSerializer
             {
 #if COMPATIBILITY
                 _buffer[0] = DataBytesDefinition.RefObject;
-                BitConverter.GetBytes(oIdx).CopyTo(_buffer, 1);
+                MemoryMarshal.Write(_buffer.AsSpan(1), ref oIdx);
                 Stream.Write(_buffer, 0, 5);
 #else
                 Span<byte> buffer = stackalloc byte[5];
@@ -907,7 +908,7 @@ namespace TWCore.Serialization.RawSerializer
             {
 #if COMPATIBILITY
                 _buffer[0] = DataBytesDefinition.RefType;
-                BitConverter.GetBytes(tIdx).CopyTo(_buffer, 1);
+                MemoryMarshal.Write(_buffer.AsSpan(1), ref tIdx);
                 Stream.Write(_buffer, 0, 5);
 #else
                 Span<byte> buffer = stackalloc byte[5];
@@ -951,63 +952,63 @@ namespace TWCore.Serialization.RawSerializer
         protected void WriteDefUshort(byte type, ushort value)
         {
             _buffer[0] = type;
-            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            MemoryMarshal.Write(_buffer.AsSpan(1), ref value);
             Stream.Write(_buffer, 0, 3);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDefInt(byte type, int value)
         {
             _buffer[0] = type;
-            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            MemoryMarshal.Write(_buffer.AsSpan(1), ref value);
             Stream.Write(_buffer, 0, 5);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDefDouble(byte type, double value)
         {
             _buffer[0] = type;
-            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            MemoryMarshal.Write(_buffer.AsSpan(1), ref value);
             Stream.Write(_buffer, 0, 9);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDefFloat(byte type, float value)
         {
             _buffer[0] = type;
-            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            MemoryMarshal.Write(_buffer.AsSpan(1), ref value);
             Stream.Write(_buffer, 0, 5);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDefLong(byte type, long value)
         {
             _buffer[0] = type;
-            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            MemoryMarshal.Write(_buffer.AsSpan(1), ref value);
             Stream.Write(_buffer, 0, 9);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDefULong(byte type, ulong value)
         {
             _buffer[0] = type;
-            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            MemoryMarshal.Write(_buffer.AsSpan(1), ref value);
             Stream.Write(_buffer, 0, 9);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDefUInt(byte type, uint value)
         {
             _buffer[0] = type;
-            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            MemoryMarshal.Write(_buffer.AsSpan(1), ref value);
             Stream.Write(_buffer, 0, 5);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDefShort(byte type, short value)
         {
             _buffer[0] = type;
-            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            MemoryMarshal.Write(_buffer.AsSpan(1), ref value);
             Stream.Write(_buffer, 0, 3);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDefChar(byte type, char value)
         {
             _buffer[0] = type;
-            BitConverter.GetBytes(value).CopyTo(_buffer, 1);
+            MemoryMarshal.Write(_buffer.AsSpan(1), ref value);
             Stream.Write(_buffer, 0, 3);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1016,61 +1017,61 @@ namespace TWCore.Serialization.RawSerializer
             _buffer[0] = type;
             var bits = decimal.GetBits(value);
             for (var i = 0; i < 4; i++)
-                BitConverter.GetBytes(bits[i]).CopyTo(_buffer, (i * 4) + 1);
+                MemoryMarshal.Write(_buffer.AsSpan((i * 4) + 1), ref bits[i]);
             Stream.Write(_buffer, 0, 17);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteUshort(ushort value)
         {
-            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            MemoryMarshal.Write(_buffer, ref value);
             Stream.Write(_buffer, 0, 2);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteInt(int value)
         {
-            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            MemoryMarshal.Write(_buffer, ref value);
             Stream.Write(_buffer, 0, 4);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteDouble(double value)
         {
-            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            MemoryMarshal.Write(_buffer, ref value);
             Stream.Write(_buffer, 0, 8);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteFloat(float value)
         {
-            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            MemoryMarshal.Write(_buffer, ref value);
             Stream.Write(_buffer, 0, 4);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteLong(long value)
         {
-            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            MemoryMarshal.Write(_buffer, ref value);
             Stream.Write(_buffer, 0, 8);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteULong(ulong value)
         {
-            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            MemoryMarshal.Write(_buffer, ref value);
             Stream.Write(_buffer, 0, 8);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteUInt(uint value)
         {
-            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            MemoryMarshal.Write(_buffer, ref value);
             Stream.Write(_buffer, 0, 4);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteShort(short value)
         {
-            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            MemoryMarshal.Write(_buffer, ref value);
             Stream.Write(_buffer, 0, 2);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteChar(char value)
         {
-            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            MemoryMarshal.Write(_buffer, ref value);
             Stream.Write(_buffer, 0, 2);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1078,14 +1079,13 @@ namespace TWCore.Serialization.RawSerializer
         {
             var bits = decimal.GetBits(value);
             for (var i = 0; i < 4; i++)
-                BitConverter.GetBytes(bits[i]).CopyTo(_buffer, i * 4);
+                MemoryMarshal.Write(_buffer.AsSpan(i * 4), ref bits[i]);
             Stream.Write(_buffer, 0, 16);
-
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void WriteSByte(sbyte value)
         {
-            BitConverter.GetBytes(value).CopyTo(_buffer, 0);
+            MemoryMarshal.Write(_buffer, ref value);
             Stream.Write(_buffer, 0, 1);
         }
 #else

--- a/src/TWCore.Serialization.RawSerializer/TWCore.Serialization.RawSerializer.csproj
+++ b/src/TWCore.Serialization.RawSerializer/TWCore.Serialization.RawSerializer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Serialization.RawSerializer</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Serialization.RawSerializer/TWCore.Serialization.RawSerializer.csproj
+++ b/src/TWCore.Serialization.RawSerializer/TWCore.Serialization.RawSerializer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Serialization.RawSerializer</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Serialization.RawSerializer/Types/GuidSerializer.cs
+++ b/src/TWCore.Serialization.RawSerializer/Types/GuidSerializer.cs
@@ -30,9 +30,15 @@ namespace TWCore.Serialization.RawSerializer
                 WriteByte(DataBytesDefinition.GuidDefault);
             else
             {
+#if NETSTANDARD2_0
+                var bytes = new byte[17];
+                bytes[0] = DataBytesDefinition.Guid;
+                value.ToByteArray().CopyTo(bytes, 1);
+#else
                 Span<byte> bytes = stackalloc byte[17];
                 bytes[0] = DataBytesDefinition.Guid;
                 value.TryWriteBytes(bytes.Slice(1));
+#endif
                 Stream.Write(bytes);
             }
         }

--- a/src/TWCore.Serialization.RawSerializer/Types/GuidSerializer.cs
+++ b/src/TWCore.Serialization.RawSerializer/Types/GuidSerializer.cs
@@ -30,7 +30,7 @@ namespace TWCore.Serialization.RawSerializer
                 WriteByte(DataBytesDefinition.GuidDefault);
             else
             {
-#if NETSTANDARD2_0
+#if COMPATIBILITY
                 var bytes = new byte[17];
                 bytes[0] = DataBytesDefinition.Guid;
                 value.ToByteArray().CopyTo(bytes, 1);

--- a/src/TWCore.Serialization.RawSerializer/Types/StringSerializer.cs
+++ b/src/TWCore.Serialization.RawSerializer/Types/StringSerializer.cs
@@ -38,7 +38,7 @@ namespace TWCore.Serialization.RawSerializer
                 return;
             }
 
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             var length = Encoding.UTF8.GetByteCount(value);
 
             var bufferLength = length + 5;
@@ -100,7 +100,7 @@ namespace TWCore.Serialization.RawSerializer
 
             string strValue = null;
 
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             var buffer = ArrayPool<byte>.Shared.Rent(length);
             try
             {

--- a/src/TWCore.Serialization.RawSerializer/Types/StringSerializer.cs
+++ b/src/TWCore.Serialization.RawSerializer/Types/StringSerializer.cs
@@ -17,6 +17,7 @@ limitations under the License.
 using System;
 using System.Buffers;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 #pragma warning disable 1591
 
@@ -45,7 +46,7 @@ namespace TWCore.Serialization.RawSerializer
             var buffer = ArrayPool<byte>.Shared.Rent(bufferLength);
             var bufferSpan = buffer.AsSpan(0, bufferLength);
             buffer[0] = DataBytesDefinition.StringLength;
-            BitConverter.GetBytes(length).CopyTo(bufferSpan.Slice(1, 4));
+            MemoryMarshal.Write(bufferSpan.Slice(1, 4), ref length);
             Encoding.UTF8.GetBytes(value, 0, value.Length, buffer, 5);
             Stream.Write(buffer, 0, bufferLength);
             ArrayPool<byte>.Shared.Return(buffer);

--- a/src/TWCore.Serialization.Utf8Json/TWCore.Serialization.Utf8Json.csproj
+++ b/src/TWCore.Serialization.Utf8Json/TWCore.Serialization.Utf8Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Serialization.Utf8Json</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Serialization.Utf8Json/TWCore.Serialization.Utf8Json.csproj
+++ b/src/TWCore.Serialization.Utf8Json/TWCore.Serialization.Utf8Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Serialization.Utf8Json</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Serialization.WSerializer/TWCore.Serialization.WSerializer.csproj
+++ b/src/TWCore.Serialization.WSerializer/TWCore.Serialization.WSerializer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Serialization.WSerializer</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Serialization.WSerializer/TWCore.Serialization.WSerializer.csproj
+++ b/src/TWCore.Serialization.WSerializer/TWCore.Serialization.WSerializer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Serialization.WSerializer</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Services/ServicesContainerParameters.cs
+++ b/src/TWCore.Services/ServicesContainerParameters.cs
@@ -23,10 +23,25 @@ namespace TWCore.Services
     public class ServicesContainerParameters : ICoreStart
     {
         /// <summary>
-        /// TWCore initialization
+        /// Before Init
         /// </summary>
-        /// <param name="factories">Factories</param>
-        public void CoreInit(Factories factories)
+        public void BeforeInit()
+        {
+        }
+
+        /// <summary>
+        /// After Factory Init
+        /// </summary>
+        /// <param name="factories">Factory instance</param>
+        public void AfterFactoryInit(Factories factories)
+        {
+        }
+
+        /// <summary>
+        /// Finalizing Init
+        /// </summary>
+        /// <param name="factories">Factory instance</param>
+        public void FinalizingInit(Factories factories)
         {
             switch (factories.PlatformType)
             {

--- a/src/TWCore.Services/TWCore.Services.csproj
+++ b/src/TWCore.Services/TWCore.Services.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Services</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Services/TWCore.Services.csproj
+++ b/src/TWCore.Services/TWCore.Services.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Services</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Triggers/TWCore.Triggers.csproj
+++ b/src/TWCore.Triggers/TWCore.Triggers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Triggers</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Triggers/TWCore.Triggers.csproj
+++ b/src/TWCore.Triggers/TWCore.Triggers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Triggers</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Web/TWCore.Web.csproj
+++ b/src/TWCore.Web/TWCore.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore.Web</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore.Web/TWCore.Web.csproj
+++ b/src/TWCore.Web/TWCore.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore.Web</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TWCore/Compression/BrotliCompressor.cs
+++ b/src/TWCore/Compression/BrotliCompressor.cs
@@ -20,7 +20,7 @@ using System.Runtime.CompilerServices;
 
 namespace TWCore.Compression
 {
-#if NETSTANDARD2_0
+#if COMPATIBILITY
 #else
     /// <inheritdoc />
     /// <summary>

--- a/src/TWCore/Compression/BrotliCompressor.cs
+++ b/src/TWCore/Compression/BrotliCompressor.cs
@@ -20,6 +20,8 @@ using System.Runtime.CompilerServices;
 
 namespace TWCore.Compression
 {
+#if NETSTANDARD2_0
+#else
     /// <inheritdoc />
     /// <summary>
     /// Implements a Brotli Compresor
@@ -53,4 +55,5 @@ namespace TWCore.Compression
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override Stream GetDecompressionStream(Stream source) => new BrotliStream(source, CompressionMode.Decompress, true);
     }
+#endif
 }

--- a/src/TWCore/Compression/CompressorManager.cs
+++ b/src/TWCore/Compression/CompressorManager.cs
@@ -35,7 +35,7 @@ namespace TWCore.Compression
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static CompressorManager()
         {
-#if NETSTANDARD2_0
+#if COMPATIBILITY
 #else
             Register(new BrotliCompressor());
 #endif

--- a/src/TWCore/Compression/CompressorManager.cs
+++ b/src/TWCore/Compression/CompressorManager.cs
@@ -35,7 +35,10 @@ namespace TWCore.Compression
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static CompressorManager()
         {
+#if NETSTANDARD2_0
+#else
             Register(new BrotliCompressor());
+#endif
             Register(new GZipCompressor());
             Register(new DeflateCompressor());
         }

--- a/src/TWCore/Core.cs
+++ b/src/TWCore/Core.cs
@@ -337,16 +337,19 @@ namespace TWCore
             }
             #endregion
 
-            Status.Attach(() =>
+            Task.Run(() =>
             {
-                if (Settings is null) return null;
-                var sItem = new StatusItem
+                Status.Attach(() =>
                 {
-                    Name = "Application Information\\Settings"
-                };
-                foreach (var i in Settings.OrderBy(i => i.Key))
-                    sItem.Values.Add(i.Key, i.Value);
-                return sItem;
+                    if (Settings is null) return null;
+                    var sItem = new StatusItem
+                    {
+                        Name = "Application Information\\Settings"
+                    };
+                    foreach (var i in Settings.OrderBy(i => i.Key))
+                        sItem.Values.Add(i.Key, i.Value);
+                    return sItem;
+                });
             });
 
             var onError = false;

--- a/src/TWCore/Core.cs
+++ b/src/TWCore/Core.cs
@@ -173,6 +173,20 @@ namespace TWCore
         /// Instance identifier
         /// </summary>
         public static Guid InstanceId { get; } = Guid.NewGuid();
+        /// <summary>
+        /// Get if the optimized version is loaded
+        /// </summary>
+        public static bool IsOptimizedVersion
+        {
+            get
+            {
+#if NETSTANDARD2_0
+                return false;
+#else
+                return true;
+#endif
+            }
+        }
 		#endregion
 
 		#region Init

--- a/src/TWCore/Core.cs
+++ b/src/TWCore/Core.cs
@@ -201,6 +201,7 @@ namespace TWCore
             if (_initialized) return;
             _initialized = true;
             UpdateLocalUtcTimer = new Timer(UpdateLocalUtc, null, 0, 5000);
+            Factory.SetFactories(factories);
             var coreInits = GetCoreInits();
 
             #region CoreStart.BeforeInit
@@ -217,7 +218,6 @@ namespace TWCore
             }
             #endregion
 
-            Factory.SetFactories(factories);
             Status = Factory.CreateStatusEngine();
             Log = Factory.CreateLogEngine();
             Trace = Factory.CreateTraceEngine();

--- a/src/TWCore/Core.cs
+++ b/src/TWCore/Core.cs
@@ -337,7 +337,8 @@ namespace TWCore
                 {
                     Name = "Application Information\\Settings"
                 };
-                Settings.OrderBy(i => i.Key).Each(i => sItem.Values.Add(i.Key, i.Value));
+                foreach (var i in Settings.OrderBy(i => i.Key))
+                    sItem.Values.Add(i.Key, i.Value);
                 return sItem;
             });
 

--- a/src/TWCore/Core.cs
+++ b/src/TWCore/Core.cs
@@ -180,7 +180,7 @@ namespace TWCore
         {
             get
             {
-#if NETSTANDARD2_0
+#if COMPATIBILITY
                 return false;
 #else
                 return true;

--- a/src/TWCore/DefaultFactories.cs
+++ b/src/TWCore/DefaultFactories.cs
@@ -201,7 +201,7 @@ namespace TWCore
         {
             //https://blogs.msdn.microsoft.com/dbrowne/2012/07/03/how-to-generate-sequential-guids-for-sql-server-in-net/
             UuidCreateSequential(out var guid);
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             var t = new byte[16];
             var s = guid.ToByteArray();
             t[3] = s[0];

--- a/src/TWCore/DefaultFactories.cs
+++ b/src/TWCore/DefaultFactories.cs
@@ -439,6 +439,7 @@ namespace TWCore
         private static Lazy<StatusItemValueItem[]> CoreFrameworkStatusItems = new Lazy<StatusItemValueItem[]>(() => new[]
         {
             new StatusItemValueItem("Version", Core.FrameworkVersion),
+            new StatusItemValueItem("Optimized", Core.IsOptimizedVersion),
             new StatusItemValueItem("Debug Mode", Core.DebugMode),
             new StatusItemValueItem("Environment", Core.EnvironmentName),
             new StatusItemValueItem("MachineName", Core.MachineName),

--- a/src/TWCore/DefaultFactories.cs
+++ b/src/TWCore/DefaultFactories.cs
@@ -278,6 +278,7 @@ namespace TWCore
                    assemblyName.Equals("NETStandard", StringComparison.OrdinalIgnoreCase) ||
                    assemblyName.StartsWith("System.", StringComparison.OrdinalIgnoreCase) ||
                    assemblyName.Equals("System", StringComparison.OrdinalIgnoreCase) ||
+                   assemblyName.StartsWith("WindowsBase", StringComparison.OrdinalIgnoreCase) ||
                    assemblyName.StartsWith("SOS.NETCore", StringComparison.OrdinalIgnoreCase) ||
                    assemblyName.StartsWith("Newtonsoft.", StringComparison.OrdinalIgnoreCase) ||
                    assemblyName.StartsWith("SQLitePCLRaw.", StringComparison.OrdinalIgnoreCase) ||
@@ -285,6 +286,9 @@ namespace TWCore
                    assemblyName.StartsWith("RabbitMQ.", StringComparison.OrdinalIgnoreCase) ||
                    assemblyName.Equals("mscorlib", StringComparison.OrdinalIgnoreCase) ||
                    assemblyName.StartsWith("Remotion.", StringComparison.OrdinalIgnoreCase) ||
+                   assemblyName.StartsWith("Eto.", StringComparison.OrdinalIgnoreCase) ||
+                   assemblyName.StartsWith("Xceed.", StringComparison.OrdinalIgnoreCase) ||
+                   assemblyName.StartsWith("api-ms-", StringComparison.OrdinalIgnoreCase) ||
                    assemblyName.StartsWith("Runtime.", StringComparison.OrdinalIgnoreCase);
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/TWCore/DefaultFactories.cs
+++ b/src/TWCore/DefaultFactories.cs
@@ -201,6 +201,27 @@ namespace TWCore
         {
             //https://blogs.msdn.microsoft.com/dbrowne/2012/07/03/how-to-generate-sequential-guids-for-sql-server-in-net/
             UuidCreateSequential(out var guid);
+#if NETSTANDARD2_0
+            var t = new byte[16];
+            var s = guid.ToByteArray();
+            t[3] = s[0];
+            t[2] = s[1];
+            t[1] = s[2];
+            t[0] = s[3];
+            t[5] = s[4];
+            t[4] = s[5];
+            t[7] = s[6];
+            t[6] = s[7];
+            t[8] = s[8];
+            t[9] = s[9];
+            t[10] = s[10];
+            t[11] = s[11];
+            t[12] = s[12];
+            t[13] = s[13];
+            t[14] = s[14];
+            t[15] = s[15];
+            return new Guid(t);
+#else
             Span<byte> s = stackalloc byte[16];
             Span<byte> t = stackalloc byte[16];
             if (!guid.TryWriteBytes(s)) return guid;
@@ -221,6 +242,7 @@ namespace TWCore
             t[14] = s[14];
             t[15] = s[15];
             return new Guid(t);
+#endif
         }
 
         #endregion

--- a/src/TWCore/Diagnostics/Status/DefaultStatusEngine.cs
+++ b/src/TWCore/Diagnostics/Status/DefaultStatusEngine.cs
@@ -287,7 +287,7 @@ namespace TWCore.Diagnostics.Status
                                 lstWithSlashName.Add((value, slashIdx));
 
                             if (!dctByName.TryGetValue(name, out var currentValue))
-                                dctByName.TryAdd(name, value);
+                                dctByName[name] = value;
                         }
                     } while (_weakValues.Count != initialCount);
                     #endregion

--- a/src/TWCore/Extensions/ExtCompatibility.cs
+++ b/src/TWCore/Extensions/ExtCompatibility.cs
@@ -21,14 +21,15 @@ using System.Buffers;
 using System.Collections.Concurrent;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace TWCore
 {
 #if COMPATIBILITY
     /// <summary>
-    /// Extension for NetStandard Compatibility
+    /// Extension for Compatibility
     /// </summary>
-    public static class ExtNetStandard
+    public static class ExtCompatibility
     {
         /// <summary>
         /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/>
@@ -74,6 +75,13 @@ namespace TWCore
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Write(this Stream stream, ReadOnlySpan<byte> buffer)
         {
+            if (buffer.IsEmpty) return;
+            if (buffer.Length == 1)
+            {
+                stream.WriteByte(buffer[0]);
+                return;
+            }
+
             var bufferByte = ArrayPool<byte>.Shared.Rent(buffer.Length);
             try
             {

--- a/src/TWCore/Extensions/ExtGeneral.cs
+++ b/src/TWCore/Extensions/ExtGeneral.cs
@@ -775,7 +775,7 @@ namespace TWCore
             dateData[20] = (char)(millisecond / 100 + 48);
             dateData[21] = (char)(millisecond / 10 % 10 + 48);
             dateData[22] = (char)(millisecond % 10 + 48);
-            return new string(dateData);
+            return dateData.ToString();
         }
         #endregion
 

--- a/src/TWCore/Extensions/ExtNetStandard.cs
+++ b/src/TWCore/Extensions/ExtNetStandard.cs
@@ -1,0 +1,67 @@
+﻿/*
+Copyright 2015-2018 Daniel Adrian Redondo Suarez
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+// ReSharper disable CheckNamespace
+
+using System;
+using System.Collections.Concurrent;
+
+namespace TWCore
+{
+#if NETSTANDARD2_0
+    /// <summary>
+    /// Extension for NetStandard Compatibility
+    /// </summary>
+    public static class ExtNetStandard
+    {
+        /// <summary>
+        /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/>
+        /// if the key does not already exist.
+        /// </summary>
+        /// <param name="item">Item to extend</param>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="valueFactory">The function used to generate a value for the key</param>
+        /// <param name="factoryArgument">An argument value to pass into <paramref name="valueFactory"/>.</param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="valueFactory"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.OverflowException">The dictionary contains too many
+        /// elements.</exception>
+        /// <returns>The value for the key.  This will be either the existing value for the key if the
+        /// key is already in the dictionary, or the new value for the key as returned by valueFactory
+        /// if the key was not in the dictionary.</returns>
+        public static TValue GetOrAdd<TKey, TValue, TArg>(this ConcurrentDictionary<TKey, TValue> item, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument)
+        {
+            return item.GetOrAdd(key, mKey => valueFactory(key, factoryArgument));
+        }
+        /// <summary>
+        /// Reports the zero-based index of the first occurrence of the specified char 
+        /// in the current System.String object. A parameter specifies the type of search 
+        /// to use for the specified char.
+        /// </summary>
+        /// <param name="str">Item to extend</param>
+        /// <param name="value">The char to seek.</param>
+        /// <param name="comparisonType">One of the enumeration values that specifies the rules for the search.</param>
+        /// <returns>The index position of the value parameter if that char is found, or -1 if it is not.</returns>
+        public static int IndexOf(this string str, char value, StringComparison comparisonType)
+        {
+            return str.IndexOf(value.ToString(), comparisonType);
+        }
+
+    }
+#endif
+}

--- a/src/TWCore/Extensions/ExtNetStandard.cs
+++ b/src/TWCore/Extensions/ExtNetStandard.cs
@@ -18,6 +18,8 @@ limitations under the License.
 
 using System;
 using System.Collections.Concurrent;
+using System.IO;
+using System.Runtime.CompilerServices;
 
 namespace TWCore
 {
@@ -44,6 +46,7 @@ namespace TWCore
         /// <returns>The value for the key.  This will be either the existing value for the key if the
         /// key is already in the dictionary, or the new value for the key as returned by valueFactory
         /// if the key was not in the dictionary.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TValue GetOrAdd<TKey, TValue, TArg>(this ConcurrentDictionary<TKey, TValue> item, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument)
         {
             return item.GetOrAdd(key, mKey => valueFactory(key, factoryArgument));
@@ -57,11 +60,132 @@ namespace TWCore
         /// <param name="value">The char to seek.</param>
         /// <param name="comparisonType">One of the enumeration values that specifies the rules for the search.</param>
         /// <returns>The index position of the value parameter if that char is found, or -1 if it is not.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IndexOf(this string str, char value, StringComparison comparisonType)
         {
             return str.IndexOf(value.ToString(), comparisonType);
         }
-
+        /// <summary>
+        /// Try to write the value to the span
+        /// </summary>
+        /// <param name="destination">Span destination</param>
+        /// <param name="value">Value to write</param>
+        /// <returns>True if the value was copied to the destination; otherwise, false.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteBytes(Span<byte> destination, bool value)
+        {
+            return BitConverter.GetBytes(value).AsSpan().TryCopyTo(destination);
+        }
+        /// <summary>
+        /// Try to write the value to the span
+        /// </summary>
+        /// <param name="destination">Span destination</param>
+        /// <param name="value">Value to write</param>
+        /// <returns>True if the value was copied to the destination; otherwise, false.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteBytes(Span<byte> destination, char value)
+        {
+            return BitConverter.GetBytes(value).AsSpan().TryCopyTo(destination);
+        }
+        /// <summary>
+        /// Try to write the value to the span
+        /// </summary>
+        /// <param name="destination">Span destination</param>
+        /// <param name="value">Value to write</param>
+        /// <returns>True if the value was copied to the destination; otherwise, false.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteBytes(Span<byte> destination, double value)
+        {
+            return BitConverter.GetBytes(value).AsSpan().TryCopyTo(destination);
+        }
+        /// <summary>
+        /// Try to write the value to the span
+        /// </summary>
+        /// <param name="destination">Span destination</param>
+        /// <param name="value">Value to write</param>
+        /// <returns>True if the value was copied to the destination; otherwise, false.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteBytes(Span<byte> destination, short value)
+        {
+            return BitConverter.GetBytes(value).AsSpan().TryCopyTo(destination);
+        }
+        /// <summary>
+        /// Try to write the value to the span
+        /// </summary>
+        /// <param name="destination">Span destination</param>
+        /// <param name="value">Value to write</param>
+        /// <returns>True if the value was copied to the destination; otherwise, false.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteBytes(Span<byte> destination, int value)
+        {
+            return BitConverter.GetBytes(value).AsSpan().TryCopyTo(destination);
+        }
+        /// <summary>
+        /// Try to write the value to the span
+        /// </summary>
+        /// <param name="destination">Span destination</param>
+        /// <param name="value">Value to write</param>
+        /// <returns>True if the value was copied to the destination; otherwise, false.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteBytes(Span<byte> destination, long value)
+        {
+            return BitConverter.GetBytes(value).AsSpan().TryCopyTo(destination);
+        }
+        /// <summary>
+        /// Try to write the value to the span
+        /// </summary>
+        /// <param name="destination">Span destination</param>
+        /// <param name="value">Value to write</param>
+        /// <returns>True if the value was copied to the destination; otherwise, false.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteBytes(Span<byte> destination, float value)
+        {
+            return BitConverter.GetBytes(value).AsSpan().TryCopyTo(destination);
+        }
+        /// <summary>
+        /// Try to write the value to the span
+        /// </summary>
+        /// <param name="destination">Span destination</param>
+        /// <param name="value">Value to write</param>
+        /// <returns>True if the value was copied to the destination; otherwise, false.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteBytes(Span<byte> destination, ushort value)
+        {
+            return BitConverter.GetBytes(value).AsSpan().TryCopyTo(destination);
+        }
+        /// <summary>
+        /// Try to write the value to the span
+        /// </summary>
+        /// <param name="destination">Span destination</param>
+        /// <param name="value">Value to write</param>
+        /// <returns>True if the value was copied to the destination; otherwise, false.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteBytes(Span<byte> destination, uint value)
+        {
+            return BitConverter.GetBytes(value).AsSpan().TryCopyTo(destination);
+        }
+        /// <summary>
+        /// Try to write the value to the span
+        /// </summary>
+        /// <param name="destination">Span destination</param>
+        /// <param name="value">Value to write</param>
+        /// <returns>True if the value was copied to the destination; otherwise, false.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteBytes(Span<byte> destination, ulong value)
+        {
+            return BitConverter.GetBytes(value).AsSpan().TryCopyTo(destination);
+        }
+        /// <summary>
+        /// Write ReadOnlySpan buffer to the stream
+        /// </summary>
+        /// <param name="stream">Stream instance</param>
+        /// <param name="buffer">Buffer to write</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Write(this Stream stream, ReadOnlySpan<byte> buffer)
+        {
+            var bytes = buffer.ToArray();
+            stream.Write(bytes, 0, bytes.Length);
+        }
     }
 #endif
 }

--- a/src/TWCore/Extensions/ExtNetStandard.cs
+++ b/src/TWCore/Extensions/ExtNetStandard.cs
@@ -24,7 +24,7 @@ using System.Runtime.CompilerServices;
 
 namespace TWCore
 {
-#if NETSTANDARD2_0
+#if COMPATIBILITY
     /// <summary>
     /// Extension for NetStandard Compatibility
     /// </summary>

--- a/src/TWCore/Extensions/ExtSpan.cs
+++ b/src/TWCore/Extensions/ExtSpan.cs
@@ -147,11 +147,11 @@ namespace TWCore
                     break;
                 var value = span.Slice(0, idx);
                 if (options == StringSplitOptions.None || value.Length > 0)
-                    result.Add(new string(value));
+                    result.Add(value.ToString());
                 span = span.Slice(idx + 1);
             }
             if (options == StringSplitOptions.None || span.Length > 0)
-                result.Add(new string(span));
+                result.Add(span.ToString());
             return result;
         }
         /// <summary>
@@ -172,11 +172,11 @@ namespace TWCore
                     break;
                 var value = span.Slice(0, idx);
                 if (options == StringSplitOptions.None || value.Length > 0)
-                    result.Add(new string(value));
+                    result.Add(value.ToString());
                 span = span.Slice(idx + separator.Length);
             }
             if (options == StringSplitOptions.None || span.Length > 0)
-                result.Add(new string(span));
+                result.Add(span.ToString());
             return result;
         }
     }

--- a/src/TWCore/Extensions/ExtStream.cs
+++ b/src/TWCore/Extensions/ExtStream.cs
@@ -305,7 +305,7 @@ namespace TWCore
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Fill(this Stream stream, Span<byte> span)
         {
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             var rbyte = ArrayPool<byte>.Shared.Rent(span.Length);
             try
             {
@@ -341,7 +341,7 @@ namespace TWCore
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static async Task FillAsync(this Stream stream, Memory<byte> memory, CancellationToken cancellationToken = default)
         {
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             var rbyte = ArrayPool<byte>.Shared.Rent(memory.Length);
             try
             {

--- a/src/TWCore/Extensions/ExtString.cs
+++ b/src/TWCore/Extensions/ExtString.cs
@@ -40,9 +40,9 @@ namespace TWCore
         private static readonly char[] Space = { ' ' };
         private static readonly Lazy<LevenshteinStringDistance> LevenshteinStringDistance = new Lazy<LevenshteinStringDistance>();
         private static readonly Lazy<DamerauLevenshteinStringDistance> DamerauLevenshteinStringDistance = new Lazy<DamerauLevenshteinStringDistance>();
-        private static readonly Lazy<Regex> ShrinkRegex = new Lazy<Regex>(new Regex(@"[ ]{2,}", RegexOptions.Compiled));
-        private static readonly Lazy<Regex> InvalidXmlChars = new Lazy<Regex>(new Regex(@"(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F\uFEFF\uFFFE\uFFFF]", RegexOptions.Compiled));
-        private static readonly Lazy<Encoding> DefaultEncoding = new Lazy<Encoding>(new UTF8Encoding(false));
+        private static readonly Lazy<Regex> ShrinkRegex = new Lazy<Regex>(() => new Regex(@"[ ]{2,}", RegexOptions.Compiled));
+        private static readonly Lazy<Regex> InvalidXmlChars = new Lazy<Regex>(() => new Regex(@"(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F\uFEFF\uFFFE\uFFFF]", RegexOptions.Compiled));
+        private static readonly Lazy<Encoding> DefaultEncoding = new Lazy<Encoding>(() => new UTF8Encoding(false));
 
         #region Is? conditionals
         /// <summary>

--- a/src/TWCore/ICoreStart.cs
+++ b/src/TWCore/ICoreStart.cs
@@ -22,8 +22,16 @@ namespace TWCore
     public interface ICoreStart
     {
         /// <summary>
+        /// Before Core Init
+        /// </summary>
+        void BeforeInit();
+        /// <summary>
+        /// After Factory Init
+        /// </summary>
+        void AfterFactoryInit(Factories factories);
+        /// <summary>
         /// Core Init method
         /// </summary>
-        void CoreInit(Factories factories);
+        void FinalizingInit(Factories factories);
     }
 }

--- a/src/TWCore/MultiArray.cs
+++ b/src/TWCore/MultiArray.cs
@@ -728,7 +728,11 @@ namespace TWCore
             /// </summary>
             /// <param name="buffer">Span buffer to fill</param>
             /// <returns>The total number of bytes read into the buffer. This can be less than the number of bytes requested if that many bytes are not currently available, or zero (0) if the end of the stream has been reached.</returns>
+#if NETSTANDARD2_0
+            public int Read(Span<byte> buffer)
+#else
             public override int Read(Span<byte> buffer)
+#endif
             {
                 if (_position == _source._count)
                     return 0;
@@ -810,6 +814,6 @@ namespace TWCore
                 return segment;
             }
         }
-        #endregion
+#endregion
     }
 }

--- a/src/TWCore/MultiArray.cs
+++ b/src/TWCore/MultiArray.cs
@@ -357,6 +357,29 @@ namespace TWCore
             var (toRowIndex, toPosition) = FromGlobalIndex(_offset + _count - 1);
             for (var rowIndex = fromRowIndex; rowIndex <= toRowIndex; rowIndex++)
             {
+#if NETSTANDARD2_0
+                byte[] tmpArray;
+                int offset, length;
+                if (rowIndex == fromRowIndex)
+                {
+                    offset = fromPosition;
+                    length = fromRowIndex != toRowIndex ? _segmentsLength - fromPosition : (toPosition - fromPosition) + 1;
+                    tmpArray = arrays[rowIndex];
+                }
+                else if (rowIndex == toRowIndex)
+                {
+                    offset = 0;
+                    length = toPosition + 1;
+                    tmpArray = arrays[rowIndex];
+                }
+                else
+                {
+                    offset = 0;
+                    length = _segmentsLength;
+                    tmpArray = arrays[rowIndex];
+                }
+                stream.Write(tmpArray, offset, length);
+#else
                 Span<byte> span;
                 if (rowIndex == fromRowIndex)
                     span = arrays[rowIndex].AsSpan(fromPosition, fromRowIndex != toRowIndex ? _segmentsLength - fromPosition : (toPosition - fromPosition) + 1);
@@ -365,6 +388,7 @@ namespace TWCore
                 else
                     span = arrays[rowIndex].AsSpan(0, _segmentsLength);
                 stream.Write(span);
+#endif
             }
         }
         /// <summary>
@@ -380,6 +404,29 @@ namespace TWCore
             var (toRowIndex, toPosition) = FromGlobalIndex(_offset + _count - 1);
             for (var rowIndex = fromRowIndex; rowIndex <= toRowIndex; rowIndex++)
             {
+#if NETSTANDARD2_0
+                byte[] tmpArray;
+                int offset, length;
+                if (rowIndex == fromRowIndex)
+                {
+                    offset = fromPosition;
+                    length = fromRowIndex != toRowIndex ? _segmentsLength - fromPosition : (toPosition - fromPosition) + 1;
+                    tmpArray = arrays[rowIndex];
+                }
+                else if (rowIndex == toRowIndex)
+                {
+                    offset = 0;
+                    length = toPosition + 1;
+                    tmpArray = arrays[rowIndex];
+                }
+                else
+                {
+                    offset = 0;
+                    length = _segmentsLength;
+                    tmpArray = arrays[rowIndex];
+                }
+                await stream.WriteAsync(tmpArray, offset, length).ConfigureAwait(false);
+#else
                 Memory<byte> memory;
                 if (rowIndex == fromRowIndex)
                     memory = arrays[rowIndex].AsMemory(fromPosition, fromRowIndex != toRowIndex ? _segmentsLength - fromPosition : (toPosition - fromPosition) + 1);
@@ -388,6 +435,7 @@ namespace TWCore
                 else
                     memory = arrays[rowIndex].AsMemory(0, _segmentsLength);
                 await stream.WriteAsync(memory).ConfigureAwait(false);
+#endif
             }
         }
         /// <summary>
@@ -808,8 +856,10 @@ namespace TWCore
             
             public SequenceSegment Add(T[] segmentItem)
             {
-                var segment = new SequenceSegment(segmentItem);
-                segment.RunningIndex = RunningIndex + Memory.Length;
+                var segment = new SequenceSegment(segmentItem)
+                {
+                    RunningIndex = RunningIndex + Memory.Length
+                };
                 Next = segment;
                 return segment;
             }

--- a/src/TWCore/MultiArray.cs
+++ b/src/TWCore/MultiArray.cs
@@ -357,7 +357,7 @@ namespace TWCore
             var (toRowIndex, toPosition) = FromGlobalIndex(_offset + _count - 1);
             for (var rowIndex = fromRowIndex; rowIndex <= toRowIndex; rowIndex++)
             {
-#if NETSTANDARD2_0
+#if COMPATIBILITY
                 byte[] tmpArray;
                 int offset, length;
                 if (rowIndex == fromRowIndex)
@@ -404,7 +404,7 @@ namespace TWCore
             var (toRowIndex, toPosition) = FromGlobalIndex(_offset + _count - 1);
             for (var rowIndex = fromRowIndex; rowIndex <= toRowIndex; rowIndex++)
             {
-#if NETSTANDARD2_0
+#if COMPATIBILITY
                 byte[] tmpArray;
                 int offset, length;
                 if (rowIndex == fromRowIndex)
@@ -776,7 +776,7 @@ namespace TWCore
             /// </summary>
             /// <param name="buffer">Span buffer to fill</param>
             /// <returns>The total number of bytes read into the buffer. This can be less than the number of bytes requested if that many bytes are not currently available, or zero (0) if the end of the stream has been reached.</returns>
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             public int Read(Span<byte> buffer)
 #else
             public override int Read(Span<byte> buffer)

--- a/src/TWCore/Net/Multicast/DiscoveryService.cs
+++ b/src/TWCore/Net/Multicast/DiscoveryService.cs
@@ -129,7 +129,7 @@ namespace TWCore.Net.Multicast
         public static void Disconnect()
         {
             if (!_connected) return;
-            _sendTimer.Dispose();
+            _sendTimer?.Dispose();
             _sendTimer = null;
             PeerConnection.Disconnect();
             _connected = false;

--- a/src/TWCore/Net/Multicast/PeerConnection.cs
+++ b/src/TWCore/Net/Multicast/PeerConnection.cs
@@ -222,6 +222,40 @@ namespace TWCore.Net.Multicast
             var guid = Guid.NewGuid();
             var remain = count;
             var datagram = DatagramPool.New();
+
+#if NETSTANDARD2_0
+            var guidBytes = guid.ToByteArray();
+            var numMsgsBytes = BitConverter.GetBytes((ushort)numMsgs);
+            for (var i = 0; i < numMsgs; i++)
+            {
+                var csize = remain >= dtsize ? dtsize : remain;
+                var dGram = new Memory<byte>(datagram);
+                guidBytes.CopyTo(datagram, 0);
+                numMsgsBytes.CopyTo(datagram, 16);
+                BitConverter.GetBytes((ushort)i).CopyTo(datagram, 18);
+                BitConverter.GetBytes((ushort)csize).CopyTo(datagram, 20);
+                buffer.AsSpan(offset, csize).CopyTo(dGram.Span.Slice(22));
+                dGram.Span.Slice(csize + 22).Clear();
+
+                foreach (var c in _sendClients)
+                {
+                    if (_token.IsCancellationRequested) break;
+                    if (_endpointErrors.Contains(c.Client.LocalEndPoint)) continue;
+                    try
+                    {
+                        await c.SendAsync(datagram, PacketSize, _sendEndpoint).ConfigureAwait(false);
+                    }
+                    catch (Exception)
+                    {
+                        if (_endpointErrors.Add(c.Client.LocalEndPoint))
+                            Core.Log.Error("Error sending datagram to the multicast group on: {0}", c.Client.LocalEndPoint);
+                    }
+                }
+
+                remain -= dtsize;
+                offset += csize;
+            }
+#else
             for (var i = 0; i < numMsgs; i++)
             {
                 var csize = remain >= dtsize ? dtsize : remain;
@@ -251,6 +285,8 @@ namespace TWCore.Net.Multicast
                 remain -= dtsize;
                 offset += csize;
             }
+#endif
+
             DatagramPool.Store(datagram);
         }
         /// <summary>
@@ -267,6 +303,40 @@ namespace TWCore.Net.Multicast
             var offset = buffer.Offset;
             var remain = buffer.Count;
             var datagram = DatagramPool.New();
+
+#if NETSTANDARD2_0
+            var guidBytes = guid.ToByteArray();
+            var numMsgsBytes = BitConverter.GetBytes((ushort)numMsgs);
+            for (var i = 0; i < numMsgs; i++)
+            {
+                var csize = remain >= dtsize ? dtsize : remain;
+                var dGram = new Memory<byte>(datagram);
+                guidBytes.CopyTo(datagram, 0);
+                numMsgsBytes.CopyTo(datagram, 16);
+                BitConverter.GetBytes((ushort)i).CopyTo(datagram, 18);
+                BitConverter.GetBytes((ushort)csize).CopyTo(datagram, 20);
+                buffer.Slice(offset, csize).CopyTo(dGram.Span.Slice(22));
+                dGram.Span.Slice(csize + 22).Clear();
+
+                foreach (var c in _sendClients)
+                {
+                    if (_token.IsCancellationRequested) break;
+                    if (_endpointErrors.Contains(c.Client.LocalEndPoint)) continue;
+                    try
+                    {
+                        await c.SendAsync(datagram, PacketSize, _sendEndpoint).ConfigureAwait(false);
+                    }
+                    catch (Exception)
+                    {
+                        if (_endpointErrors.Add(c.Client.LocalEndPoint))
+                            Core.Log.Error("Error sending datagram to the multicast group on: {0}", c.Client.LocalEndPoint);
+                    }
+                }
+
+                remain -= dtsize;
+                offset += csize;
+            }
+#else
             for (var i = 0; i < numMsgs; i++)
             {
                 var csize = remain >= dtsize ? dtsize : remain;
@@ -296,6 +366,8 @@ namespace TWCore.Net.Multicast
                 remain -= dtsize;
                 offset += csize;
             }
+#endif
+
             DatagramPool.Store(datagram);
         }
         /// <summary>
@@ -328,7 +400,12 @@ namespace TWCore.Net.Multicast
                     if (datagram.Length < 22)
                         continue;
 
+#if NETSTANDARD2_0
+                    var guid = new Guid(datagram.AsSpan(0, 16).ToArray());
+#else
                     var guid = new Guid(datagram.AsSpan(0, 16));
+#endif
+
                     var numMsgs = BitConverter.ToUInt16(datagram, 16);
                     var currentMsg = BitConverter.ToUInt16(datagram, 18);
                     var dataSize = BitConverter.ToUInt16(datagram, 20);
@@ -412,8 +489,10 @@ namespace TWCore.Net.Multicast
 
             public Segment<T> Add(ReadOnlyMemory<T> mem)
             {
-                var segment = new Segment<T>(mem);
-                segment.RunningIndex = RunningIndex + Memory.Length;
+                var segment = new Segment<T>(mem)
+                {
+                    RunningIndex = RunningIndex + Memory.Length
+                };
                 Next = segment;
                 return segment;
             }

--- a/src/TWCore/Net/Multicast/PeerConnection.cs
+++ b/src/TWCore/Net/Multicast/PeerConnection.cs
@@ -23,6 +23,7 @@ using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using TWCore.Collections;
@@ -232,8 +233,10 @@ namespace TWCore.Net.Multicast
                 var dGram = new Memory<byte>(datagram);
                 guidBytes.CopyTo(datagram, 0);
                 numMsgsBytes.CopyTo(datagram, 16);
-                BitConverter.GetBytes((ushort)i).CopyTo(datagram, 18);
-                BitConverter.GetBytes((ushort)csize).CopyTo(datagram, 20);
+                var ui = (ushort)i;
+                var ucsize = (ushort)csize;
+                MemoryMarshal.Write(datagram.AsSpan(18), ref ui);
+                MemoryMarshal.Write(datagram.AsSpan(20), ref ucsize);
                 buffer.AsSpan(offset, csize).CopyTo(dGram.Span.Slice(22));
                 dGram.Span.Slice(csize + 22).Clear();
 
@@ -313,8 +316,10 @@ namespace TWCore.Net.Multicast
                 var dGram = new Memory<byte>(datagram);
                 guidBytes.CopyTo(datagram, 0);
                 numMsgsBytes.CopyTo(datagram, 16);
-                BitConverter.GetBytes((ushort)i).CopyTo(datagram, 18);
-                BitConverter.GetBytes((ushort)csize).CopyTo(datagram, 20);
+                var ui = (ushort)i;
+                var ucsize = (ushort)csize;
+                MemoryMarshal.Write(datagram.AsSpan(18), ref ui);
+                MemoryMarshal.Write(datagram.AsSpan(20), ref ucsize);
                 buffer.Slice(offset, csize).CopyTo(dGram.Span.Slice(22));
                 dGram.Span.Slice(csize + 22).Clear();
 

--- a/src/TWCore/Net/Multicast/PeerConnection.cs
+++ b/src/TWCore/Net/Multicast/PeerConnection.cs
@@ -223,7 +223,7 @@ namespace TWCore.Net.Multicast
             var remain = count;
             var datagram = DatagramPool.New();
 
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             var guidBytes = guid.ToByteArray();
             var numMsgsBytes = BitConverter.GetBytes((ushort)numMsgs);
             for (var i = 0; i < numMsgs; i++)
@@ -304,7 +304,7 @@ namespace TWCore.Net.Multicast
             var remain = buffer.Count;
             var datagram = DatagramPool.New();
 
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             var guidBytes = guid.ToByteArray();
             var numMsgsBytes = BitConverter.GetBytes((ushort)numMsgs);
             for (var i = 0; i < numMsgs; i++)
@@ -400,7 +400,7 @@ namespace TWCore.Net.Multicast
                     if (datagram.Length < 22)
                         continue;
 
-#if NETSTANDARD2_0
+#if COMPATIBILITY
                     var guid = new Guid(datagram.AsSpan(0, 16).ToArray());
 #else
                     var guid = new Guid(datagram.AsSpan(0, 16));

--- a/src/TWCore/Reflection/AssemblyResolver.cs
+++ b/src/TWCore/Reflection/AssemblyResolver.cs
@@ -309,7 +309,10 @@ namespace TWCore.Reflection
                    assemblyName.StartsWith("mscor", StringComparison.OrdinalIgnoreCase) ||
                    assemblyName.StartsWith("Remotion.", StringComparison.OrdinalIgnoreCase) ||
                    assemblyName.StartsWith("Runtime.", StringComparison.OrdinalIgnoreCase) ||
-                   assemblyName.StartsWith("api-ms-", StringComparison.OrdinalIgnoreCase);
+                   assemblyName.StartsWith("Eto.", StringComparison.OrdinalIgnoreCase) ||
+                   assemblyName.StartsWith("Xceed.", StringComparison.OrdinalIgnoreCase) ||
+                   assemblyName.StartsWith("api-ms-", StringComparison.OrdinalIgnoreCase) ||
+                   assemblyName.StartsWith("Runtime.", StringComparison.OrdinalIgnoreCase);
         }
         #endregion
 

--- a/src/TWCore/Reflection/AssemblyResolverManager.cs
+++ b/src/TWCore/Reflection/AssemblyResolverManager.cs
@@ -48,6 +48,7 @@ namespace TWCore.Reflection
         {
             if (Core.Settings[SettingsKey].IsNullOrWhitespace()) return;
             var paths = Core.Settings[SettingsKey].SplitAndTrim(',').ToArray();
+            if (paths == null || paths.Length == 0) return;
             RegisterDomain(paths, domain);
         }
         /// <summary>
@@ -58,6 +59,7 @@ namespace TWCore.Reflection
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void RegisterDomain(string[] paths, AppDomain domain = null)
         {
+            if (paths == null || paths.Length == 0) return;
             if (Resolvers.Contains(domain ?? AppDomain.CurrentDomain)) return;
             var resolver = new AssemblyResolver(domain ?? AppDomain.CurrentDomain, paths);
             resolver.LoadAssembliesInfo();

--- a/src/TWCore/Security/HashBase.cs
+++ b/src/TWCore/Security/HashBase.cs
@@ -108,7 +108,7 @@ namespace TWCore.Security
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public Guid GetGuid(MultiArray<byte> bytes) 
 		{
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             return new Guid(GetBytes(bytes).Slice(0, 16).AsArray());
 #else
             return new Guid(GetBytes(bytes).Slice(0, 16).AsSpan());

--- a/src/TWCore/Security/HashBase.cs
+++ b/src/TWCore/Security/HashBase.cs
@@ -108,8 +108,12 @@ namespace TWCore.Security
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public Guid GetGuid(MultiArray<byte> bytes) 
 		{
-			return new Guid(GetBytes(bytes).Slice(0, 16).AsSpan());
-		}
+#if NETSTANDARD2_0
+            return new Guid(GetBytes(bytes).Slice(0, 16).AsArray());
+#else
+            return new Guid(GetBytes(bytes).Slice(0, 16).AsSpan());
+#endif
+        }
 
         /// <inheritdoc />
         /// <summary>

--- a/src/TWCore/Serialization/BinarySerializer.cs
+++ b/src/TWCore/Serialization/BinarySerializer.cs
@@ -410,8 +410,10 @@ namespace TWCore.Serialization
         #endregion
 
         #region CoreStart
-        void ICoreStart.CoreInit(Factories factories)
+        void ICoreStart.BeforeInit() { }
+        void ICoreStart.AfterFactoryInit(Factories factories)
             => SerializerManager.Register(this);
+        void ICoreStart.FinalizingInit(Factories factories) { }
         #endregion
     }
 }

--- a/src/TWCore/Serialization/SerializedObject.cs
+++ b/src/TWCore/Serialization/SerializedObject.cs
@@ -210,6 +210,32 @@ namespace TWCore.Serialization
             var dataTypeLength = hasDataType ? Encoding.UTF8.GetByteCount(DataType) : 0;
             var serializerMimeTypeLength = hasMimeType ? Encoding.UTF8.GetByteCount(SerializerMimeType) : 0;
 
+#if NETSTANDARD2_0
+            byte[] buffer;
+
+            //DataType
+            buffer = BitConverter.GetBytes(hasDataType ? dataTypeLength : -1);
+            stream.WriteBytes(buffer);
+            if (hasDataType)
+            {
+                buffer = Encoding.UTF8.GetBytes(DataType);
+                stream.Write(buffer);
+            }
+
+            //MimeType
+            buffer = BitConverter.GetBytes(hasMimeType ? serializerMimeTypeLength : -1);
+            stream.WriteBytes(buffer);
+            if (hasMimeType)
+            {
+                buffer = Encoding.UTF8.GetBytes(SerializerMimeType);
+                stream.Write(buffer);
+            }
+
+            //Data
+            buffer = BitConverter.GetBytes(Data.Count);
+            stream.WriteBytes(buffer);
+            Data.CopyTo(stream);
+#else
             Span<byte> intBuffer = stackalloc byte[4];
 
             //DataType
@@ -236,6 +262,7 @@ namespace TWCore.Serialization
             BitConverter.TryWriteBytes(intBuffer, Data.Count);
             stream.Write(intBuffer);
             Data.CopyTo(stream);
+#endif
         }
         /// <summary>
         /// Write the SerializedObject to a file

--- a/src/TWCore/Serialization/SerializedObject.cs
+++ b/src/TWCore/Serialization/SerializedObject.cs
@@ -210,7 +210,7 @@ namespace TWCore.Serialization
             var dataTypeLength = hasDataType ? Encoding.UTF8.GetByteCount(DataType) : 0;
             var serializerMimeTypeLength = hasMimeType ? Encoding.UTF8.GetByteCount(SerializerMimeType) : 0;
 
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             byte[] buffer;
 
             //DataType
@@ -318,7 +318,7 @@ namespace TWCore.Serialization
             string dataType = null;
             string mimeType = null;
 
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             var lengthBytes = new byte[4];
 
             sequence.Slice(0, 4).CopyTo(lengthBytes);
@@ -406,7 +406,7 @@ namespace TWCore.Serialization
             string serializerMimeType = null;
             MultiArray<byte> data = MultiArray<byte>.Empty;
 
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             var intBuffer = new byte[4];
 
             stream.ReadExact(intBuffer, 0, 4);
@@ -502,7 +502,7 @@ namespace TWCore.Serialization
             string serializerMimeType = null;
             MultiArray<byte> data = MultiArray<byte>.Empty;
 
-#if NETSTANDARD2_0
+#if COMPATIBILITY
             var intBuffer = new byte[4];
 
             await stream.ReadExactAsync(intBuffer, 0, 4).ConfigureAwait(false);

--- a/src/TWCore/Serialization/SerializerManager.cs
+++ b/src/TWCore/Serialization/SerializerManager.cs
@@ -108,49 +108,49 @@ namespace TWCore.Serialization
             Register(new JsonTextSerializer());
             Register(new XmlTextSerializer());
             Register(new BinaryFormatterSerializer());
-            Core.RunOnInit(() =>
-            {
-                if (Factory.GetAllAssemblies != null)
-                {
-                    var assemblies = Factory.GetAllAssemblies();
-                    foreach (var assembly in assemblies)
-                    {
-                        try
-                        {
-                            foreach (var type in assembly.DefinedTypes)
-                            {
-                                if (type.IsInterface || type.IsAbstract || type.ImplementedInterfaces.All(i => i != typeof(ISerializer))) continue;
-                                var serType = type.AsType();
-                                if (serType == typeof(JsonTextSerializer)) continue;
-                                if (serType == typeof(XmlTextSerializer)) continue;
-                                if (serType == typeof(BinaryFormatterSerializer)) continue;
-                                try
-                                {
-                                    Register((ISerializer)Activator.CreateInstance(serType));
-                                }
-                                catch (Exception ex)
-                                {
-                                    Core.Log.Write(LogLevel.Warning, $"Error registering the '{serType.FullName}' serializer, the type was ignored.", ex);
-                                }
-                            }
-                        }
-                        catch (ReflectionTypeLoadException rtlEx)
-                        {
-                            if (rtlEx.LoaderExceptions != null)
-                            {
-                                Core.Log.Warning($"An error occurs when loading the types for '{assembly.FullName}', the following errors occurs:");
+            //Core.RunOnInit(() =>
+            //{
+            //    if (Factory.GetAllAssemblies != null)
+            //    {
+            //        var assemblies = Factory.GetAllAssemblies();
+            //        foreach (var assembly in assemblies)
+            //        {
+            //            try
+            //            {
+            //                foreach (var type in assembly.DefinedTypes)
+            //                {
+            //                    if (type.IsInterface || type.IsAbstract || type.ImplementedInterfaces.All(i => i != typeof(ISerializer))) continue;
+            //                    var serType = type.AsType();
+            //                    if (serType == typeof(JsonTextSerializer)) continue;
+            //                    if (serType == typeof(XmlTextSerializer)) continue;
+            //                    if (serType == typeof(BinaryFormatterSerializer)) continue;
+            //                    try
+            //                    {
+            //                        Register((ISerializer)Activator.CreateInstance(serType));
+            //                    }
+            //                    catch (Exception ex)
+            //                    {
+            //                        Core.Log.Write(LogLevel.Warning, $"Error registering the '{serType.FullName}' serializer, the type was ignored.", ex);
+            //                    }
+            //                }
+            //            }
+            //            catch (ReflectionTypeLoadException rtlEx)
+            //            {
+            //                if (rtlEx.LoaderExceptions != null)
+            //                {
+            //                    Core.Log.Warning($"An error occurs when loading the types for '{assembly.FullName}', the following errors occurs:");
 
-                                foreach (var ex in rtlEx.LoaderExceptions)
-                                    Core.Log.Write(LogLevel.Warning, "\t" + ex.Message);
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            Core.Log.Write(LogLevel.Warning, $"An error occurs when loading the types for '{assembly.FullName}' assembly, the assembly was ignored.", ex);
-                        }
-                    }
-                }
-            });
+            //                    foreach (var ex in rtlEx.LoaderExceptions)
+            //                        Core.Log.Write(LogLevel.Warning, "\t" + ex.Message);
+            //                }
+            //            }
+            //            catch (Exception ex)
+            //            {
+            //                Core.Log.Write(LogLevel.Warning, $"An error occurs when loading the types for '{assembly.FullName}' assembly, the assembly was ignored.", ex);
+            //            }
+            //        }
+            //    }
+            //});
         }
         #endregion
 

--- a/src/TWCore/Serialization/TextSerializer.cs
+++ b/src/TWCore/Serialization/TextSerializer.cs
@@ -465,8 +465,10 @@ namespace TWCore.Serialization
         #endregion
 
         #region CoreStart
-        void ICoreStart.CoreInit(Factories factories)
+        void ICoreStart.BeforeInit() { }
+        void ICoreStart.AfterFactoryInit(Factories factories)
             => SerializerManager.Register(this);
+        void ICoreStart.FinalizingInit(Factories factories) { }
         #endregion
     }
 }

--- a/src/TWCore/Services/BannerCoreStart.cs
+++ b/src/TWCore/Services/BannerCoreStart.cs
@@ -29,7 +29,9 @@ namespace TWCore.Services
     public sealed class BannerCoreStart : ICoreStart
     {
         private const string BannerFilePath = "banner.bnn";
-        void ICoreStart.CoreInit(Factories factories)
+        void ICoreStart.BeforeInit() { }
+        void ICoreStart.AfterFactoryInit(Factories factories) { }
+        void ICoreStart.FinalizingInit(Factories factories)
         {
             var entryAssembly = Assembly.GetEntryAssembly();
             var bannerText = entryAssembly.GetResourceString(BannerFilePath);

--- a/src/TWCore/Services/ContainerParameterService.cs
+++ b/src/TWCore/Services/ContainerParameterService.cs
@@ -49,8 +49,9 @@ namespace TWCore.Services
         /// <param name="info">Parameter handler info</param>
         protected abstract void OnHandler(ParameterHandlerInfo info);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        void ICoreStart.CoreInit(Factories factories)
+        void ICoreStart.BeforeInit() { }
+        void ICoreStart.AfterFactoryInit(Factories factories) { }
+        void ICoreStart.FinalizingInit(Factories factories)
             => ServiceContainer.RegisterParametersHandler(Name, Description, OnHandler);
     }
 }

--- a/src/TWCore/Services/ContainerParameterServiceAsync.cs
+++ b/src/TWCore/Services/ContainerParameterServiceAsync.cs
@@ -60,8 +60,9 @@ namespace TWCore.Services
         private void OnHandler(ParameterHandlerInfo info) 
             => OnHandlerAsync(info).WaitAsync();
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        void ICoreStart.CoreInit(Factories factories)
+        void ICoreStart.BeforeInit() { }
+        void ICoreStart.AfterFactoryInit(Factories factories) { }
+        void ICoreStart.FinalizingInit(Factories factories)
             => ServiceContainer.RegisterParametersHandler(Name, Description, OnHandler);
     }
 }

--- a/src/TWCore/Services/ServiceContainer.cs
+++ b/src/TWCore/Services/ServiceContainer.cs
@@ -283,7 +283,7 @@ namespace TWCore.Services
                 Core.Log.InfoBasic(" Arguments: {0}", strArgs);
             Core.Log.InfoBasic(string.Format(" Service Name: {0}", ServiceName).PadRight(54) + "      " + string.Format("Environment Name: {0}", Core.EnvironmentName).PadRight(55));
             Core.Log.InfoBasic(string.Format(" Application Name: {0}", Core.ApplicationName).PadRight(54) + "      " + string.Format("Application Display: {0}", Core.ApplicationDisplayName).PadRight(55));
-            Core.Log.InfoBasic(string.Format(" Machine Name: {0}", Core.MachineName).PadRight(54) + "      " + string.Format("TWCore Version: {0} {1}", Core.FrameworkVersion, Core.IsOptimizedVersion ? "Opt" : string.Empty).PadRight(55));
+            Core.Log.InfoBasic(string.Format(" Machine Name: {0}", Core.MachineName).PadRight(54) + "      " + string.Format("TWCore Version: {0} {1}", Core.FrameworkVersion, Core.IsOptimizedVersion ? "O" : string.Empty).PadRight(55));
 
             if (_discovery)
                 Core.Log.InfoBasic(" Discovery Services: True [ReceiveThread = {0}]", !Core.GlobalSettings.DiscoveryDisableReceive);

--- a/src/TWCore/Services/ServiceContainer.cs
+++ b/src/TWCore/Services/ServiceContainer.cs
@@ -283,7 +283,7 @@ namespace TWCore.Services
                 Core.Log.InfoBasic(" Arguments: {0}", strArgs);
             Core.Log.InfoBasic(string.Format(" Service Name: {0}", ServiceName).PadRight(54) + "      " + string.Format("Environment Name: {0}", Core.EnvironmentName).PadRight(55));
             Core.Log.InfoBasic(string.Format(" Application Name: {0}", Core.ApplicationName).PadRight(54) + "      " + string.Format("Application Display: {0}", Core.ApplicationDisplayName).PadRight(55));
-            Core.Log.InfoBasic(string.Format(" Machine Name: {0}", Core.MachineName).PadRight(54) + "      " + string.Format("TWCore Version: {0} {1}", Core.FrameworkVersion, Core.IsOptimizedVersion ? "O" : string.Empty).PadRight(55));
+            Core.Log.InfoBasic(string.Format(" Machine Name: {0}", Core.MachineName).PadRight(54) + "      " + string.Format("TWCore Version: {0} {1}", Core.FrameworkVersion, Core.IsOptimizedVersion ? "[O]" : string.Empty).PadRight(55));
 
             if (_discovery)
                 Core.Log.InfoBasic(" Discovery Services: True [ReceiveThread = {0}]", !Core.GlobalSettings.DiscoveryDisableReceive);

--- a/src/TWCore/Services/ServiceContainer.cs
+++ b/src/TWCore/Services/ServiceContainer.cs
@@ -283,7 +283,7 @@ namespace TWCore.Services
                 Core.Log.InfoBasic(" Arguments: {0}", strArgs);
             Core.Log.InfoBasic(string.Format(" Service Name: {0}", ServiceName).PadRight(54) + "      " + string.Format("Environment Name: {0}", Core.EnvironmentName).PadRight(55));
             Core.Log.InfoBasic(string.Format(" Application Name: {0}", Core.ApplicationName).PadRight(54) + "      " + string.Format("Application Display: {0}", Core.ApplicationDisplayName).PadRight(55));
-            Core.Log.InfoBasic(string.Format(" Machine Name: {0}", Core.MachineName).PadRight(54) + "      " + string.Format("TWCore Version: {0} [Optimized = {1}]", Core.FrameworkVersion, Core.IsOptimizedVersion).PadRight(55));
+            Core.Log.InfoBasic(string.Format(" Machine Name: {0}", Core.MachineName).PadRight(54) + "      " + string.Format("TWCore Version: {0} {1}", Core.FrameworkVersion, Core.IsOptimizedVersion ? "Opt" : string.Empty).PadRight(55));
 
             if (_discovery)
                 Core.Log.InfoBasic(" Discovery Services: True [ReceiveThread = {0}]", !Core.GlobalSettings.DiscoveryDisableReceive);

--- a/src/TWCore/Services/ServiceContainer.cs
+++ b/src/TWCore/Services/ServiceContainer.cs
@@ -283,7 +283,7 @@ namespace TWCore.Services
                 Core.Log.InfoBasic(" Arguments: {0}", strArgs);
             Core.Log.InfoBasic(string.Format(" Service Name: {0}", ServiceName).PadRight(54) + "      " + string.Format("Environment Name: {0}", Core.EnvironmentName).PadRight(55));
             Core.Log.InfoBasic(string.Format(" Application Name: {0}", Core.ApplicationName).PadRight(54) + "      " + string.Format("Application Display: {0}", Core.ApplicationDisplayName).PadRight(55));
-            Core.Log.InfoBasic(string.Format(" Machine Name: {0}", Core.MachineName).PadRight(54) + "      " + string.Format("TWCore Version: {0}", Core.FrameworkVersion).PadRight(55));
+            Core.Log.InfoBasic(string.Format(" Machine Name: {0}", Core.MachineName).PadRight(54) + "      " + string.Format("TWCore Version: {0} [Optimized = {1}]", Core.FrameworkVersion, Core.IsOptimizedVersion).PadRight(55));
 
             if (_discovery)
                 Core.Log.InfoBasic(" Discovery Services: True [ReceiveThread = {0}]", !Core.GlobalSettings.DiscoveryDisableReceive);

--- a/src/TWCore/Settings/SettingsEngine.cs
+++ b/src/TWCore/Settings/SettingsEngine.cs
@@ -49,10 +49,11 @@ namespace TWCore.Settings
             string shortContainer = null;
             if (container.EndsWith("Settings"))
                 shortContainer = container.Substring(0, container.LastIndexOf("Settings", StringComparison.Ordinal));
-            var props = type.GetProperties().Where(p => p.CanRead && p.CanWrite && !p.IsSpecialName);
             var provider = System.Globalization.CultureInfo.InvariantCulture;
-            props.Each(p =>
+            foreach(var p in type.GetProperties())
             {
+                if (!p.CanRead || !p.CanWrite || p.IsSpecialName) continue;
+
                 var sKeys = p.GetAttribute<SettingsKeyAttribute>();
                 var attribute = p.GetAttribute<SettingsDataFormatAttribute>();
                 var arrayAttribute = p.GetAttribute<SettingsArrayAttribute>();
@@ -130,7 +131,7 @@ namespace TWCore.Settings
 
                     p.SetValue(instance, isDefaultValue ? p.GetValue(instance) : myValueArray);
                 }
-            });
+            }
         }
     }
 }

--- a/src/TWCore/TWCore.csproj
+++ b/src/TWCore/TWCore.csproj
@@ -1,10 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Title>TWCore</Title>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Memory" Version="4.5.1" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+  </ItemGroup>
+  
 </Project>

--- a/src/TWCore/TWCore.csproj
+++ b/src/TWCore/TWCore.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\commonWithDoc.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0;net461;net462</TargetFrameworks>
     <Title>TWCore</Title>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net461'  Or '$(TargetFramework)' == 'net462'">
     <PackageReference Include="System.Memory" Version="4.5.1" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/TWCore/Threading/AsyncLock.cs
+++ b/src/TWCore/Threading/AsyncLock.cs
@@ -79,6 +79,74 @@ namespace TWCore.Threading
         }
 
         /// <summary>
+        /// Locks the <see cref="AsyncLock"/>.
+        /// </summary>
+        /// <param name="action">Action to execute in the lock</param>
+        public void Lock(Action action)
+        {
+            _semaphore.Wait();
+            try
+            {
+                action();
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+        /// <summary>
+        /// Locks the <see cref="AsyncLock"/>.
+        /// </summary>
+        /// <param name="action">Action to execute in the lock</param>
+        /// <param name="state">State instance</param>
+        public void Lock<T>(Action<T> action, T state)
+        {
+            _semaphore.Wait();
+            try
+            {
+                action(state);
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+        
+        /// <summary>
+        /// Locks the <see cref="AsyncLock"/>.
+        /// </summary>
+        /// <param name="func">Func to execute in the lock</param>
+        public TResult Lock<TResult>(Func<TResult> func)
+        {
+            _semaphore.Wait();
+            try
+            {
+                return func();
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+        /// <summary>
+        /// Locks the <see cref="AsyncLock"/>.
+        /// </summary>
+        /// <param name="func">Func to execute in the lock</param>
+        /// <param name="state">State instance</param>
+        public TResult Lock<T, TResult>(Func<T, TResult> func, T state)
+        {
+            _semaphore.Wait();
+            try
+            {
+                return func(state);
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+        
+        /// <summary>
         /// <see cref="T:TWCore.AsyncLock.Releaser" /> enables holding an <see cref="T:TWCore.AsyncLock" /> with a using scope.
         /// </summary>
         public struct Releaser : IDisposable

--- a/test/TWCore.Test.Core/Program.cs
+++ b/test/TWCore.Test.Core/Program.cs
@@ -70,8 +70,6 @@ namespace TWCore.Test.Core
         {
             Console.WriteLine("MAIN");
 
-            SerializerManager.DefaultBinarySerializer = new NBinarySerializer();
-
             TWCore.Core.DebugMode = true;
             TWCore.Core.RunOnInit(() =>
             {

--- a/test/TWCore.Test.Core/Properties/launchSettings.json
+++ b/test/TWCore.Test.Core/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "TWCore.Test.Core": {
       "commandName": "Project",
-      "commandLineArgs": "/rabbitmqtest"
+      "commandLineArgs": "/serializertest"
     }
   }
 }

--- a/test/TWCore.Test.Core/TWCore.Test.Core.csproj
+++ b/test/TWCore.Test.Core/TWCore.Test.Core.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net472;net461</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <TieredCompilation>true</TieredCompilation>
   </PropertyGroup>

--- a/test/TWCore.Test.Core/TWCore.Test.Core.csproj
+++ b/test/TWCore.Test.Core/TWCore.Test.Core.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <TieredCompilation>true</TieredCompilation>
   </PropertyGroup>

--- a/test/TWCore.Tests/TWCore.Tests.csproj
+++ b/test/TWCore.Tests/TWCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\common.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>

--- a/tools/TWCore.Diagnostics.Api.Models/TWCore.Diagnostics.Api.Models.csproj
+++ b/tools/TWCore.Diagnostics.Api.Models/TWCore.Diagnostics.Api.Models.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\common.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Title>TWCore.Diagnostics.Api.Models</Title>
   </PropertyGroup>
   <ItemGroup>

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
         <VersionPrefix>2.1.177</VersionPrefix>
-        <VersionSuffix>rc2</VersionSuffix>
+        <VersionSuffix>rc3</VersionSuffix>
     </PropertyGroup>
 </Project>

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>2.1.176</VersionPrefix>
-        <VersionSuffix></VersionSuffix>
+        <VersionPrefix>2.1.177</VersionPrefix>
+        <VersionSuffix>alpha</VersionSuffix>
     </PropertyGroup>
 </Project>

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
         <VersionPrefix>2.1.177</VersionPrefix>
-        <VersionSuffix>alpha</VersionSuffix>
+        <VersionSuffix>beta</VersionSuffix>
     </PropertyGroup>
 </Project>

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
         <VersionPrefix>2.1.177</VersionPrefix>
-        <VersionSuffix>rc3</VersionSuffix>
+        <VersionSuffix>rc4</VersionSuffix>
     </PropertyGroup>
 </Project>

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
         <VersionPrefix>2.1.177</VersionPrefix>
-        <VersionSuffix>rc4</VersionSuffix>
+        <VersionSuffix>rc5</VersionSuffix>
     </PropertyGroup>
 </Project>

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
         <VersionPrefix>2.1.177</VersionPrefix>
-        <VersionSuffix>rc1</VersionSuffix>
+        <VersionSuffix>rc2</VersionSuffix>
     </PropertyGroup>
 </Project>

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
         <VersionPrefix>2.1.177</VersionPrefix>
-        <VersionSuffix>beta</VersionSuffix>
+        <VersionSuffix>rc1</VersionSuffix>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
Adds support for net standard 2.0, support .Net Framework 4.6.1 and 4.6.2

Adds new methods to the CoreStart interface to have better control over the Core load.

Couples of improvements in other areas.