### PR TITLE
Diagnostics Changes

### DIFF
--- a/commonWithDoc.props
+++ b/commonWithDoc.props
@@ -1,8 +1,12 @@
 <Project>
   <Import Project="common.props" />
-  <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp2.1;netstandard2.0;net461</TargetFrameworks>
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+    <TargetFrameworks>netcoreapp2.2;netcoreapp2.1;netstandard2.0;net461;net472</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' == 'Unix'">
+    <TargetFrameworks>netcoreapp2.2;netcoreapp2.1;netstandard2.0</TargetFrameworks>
+  </PropertyGroup>
+  
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
@@ -10,4 +14,6 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net461'  Or '$(TargetFramework)' == 'net462'">
     <DefineConstants>COMPATIBILITY</DefineConstants>
   </PropertyGroup>
+  
+  
 </Project>

--- a/src/TWCore/Diagnostics/Counters/Counter.cs
+++ b/src/TWCore/Diagnostics/Counters/Counter.cs
@@ -90,8 +90,8 @@ namespace TWCore.Diagnostics.Counters
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Add(T value)
         {
-            //Now with a truncate to a second
-            var now = Core.Now.TruncateTo(TimeSpan.FromSeconds(1));
+            //Now with a truncate to 5 seconds
+            var now = Core.Now.TruncateTo(TimeSpan.FromSeconds(5));
             var lastValue = _lastValue;
             if (lastValue?.Timestamp == now)
             {

--- a/src/TWCore/Diagnostics/Counters/DefaultCountersEngine.cs
+++ b/src/TWCore/Diagnostics/Counters/DefaultCountersEngine.cs
@@ -310,7 +310,7 @@ namespace TWCore.Diagnostics.Counters
             /// <summary>
             /// Gets or sets the flush timeout in seconds
             /// </summary>
-            public int FlushTimeoutInSeconds { get; set; } = 10;
+            public int FlushTimeoutInSeconds { get; set; } = 30;
             /// <summary>
             /// Gets or sets the maximum counter values batch per counter
             /// </summary>

--- a/tools/TWCore.Diagnostics.Api.Models/DiagnosticsSettings.cs
+++ b/tools/TWCore.Diagnostics.Api.Models/DiagnosticsSettings.cs
@@ -64,6 +64,10 @@ namespace TWCore.Diagnostics
         /// <summary>
         /// Parallel messaging process
         /// </summary>
-        public int ParallelMessagingProcess { get; set; } = 2;
+        public int ParallelMessagingProcess { get; set; } = 5;
+        /// <summary>
+        /// Process timer in seconds
+        /// </summary>
+        public int ProcessTimerInSeconds { get; set; } = 10;
     }
 }


### PR DESCRIPTION
- Counters truncate values to every 5 seconds (was 1 second).
- Increase the Counters flush from 10 seconds to 30 seconds.
- Increase the Diagnostics messaging parallel processors from 2 to 5.
- Adds a Process timer to flush to the database every 10 seconds.
- Refactor RavenDB counter processor to be better in bulk inserts.
- Props file modifications.